### PR TITLE
Make it possible to parse SWOF/SGOF without TABDIMS present

### DIFF
--- a/ecl2df/eclfiles.py
+++ b/ecl2df/eclfiles.py
@@ -79,9 +79,11 @@ class EclFiles(object):
         return self._deck
 
     @staticmethod
-    def str2deck(string, recovery=SUNBEAM_RECOVERY):
+    def str2deck(string, recovery=None):
         """Produce a sunbeam deck from a string, using permissive
         parsing by default"""
+        if not recovery:
+            recovery = SUNBEAM_RECOVERY
         return sunbeam.deck.parse_string(string, recovery=recovery)
 
     @staticmethod

--- a/ecl2df/eclfiles.py
+++ b/ecl2df/eclfiles.py
@@ -79,10 +79,10 @@ class EclFiles(object):
         return self._deck
 
     @staticmethod
-    def str2deck(string):
+    def str2deck(string, recovery=SUNBEAM_RECOVERY):
         """Produce a sunbeam deck from a string, using permissive
-        parsing"""
-        return sunbeam.deck.parse_string(string, recovery=SUNBEAM_RECOVERY)
+        parsing by default"""
+        return sunbeam.deck.parse_string(string, recovery=recovery)
 
     @staticmethod
     def file2deck(filename):

--- a/ecl2df/satfunc2df.py
+++ b/ecl2df/satfunc2df.py
@@ -128,13 +128,16 @@ def deck2df(deck, satnumcount=None):
     Return:
         pd.DataFrame, columns 'SW', 'KRW', 'KROW', 'PC', ..
     """
-    if not "TABDIMS" in deck:
+    if "TABDIMS" not in deck:
         if not isinstance(deck, str):
             logging.critical(
                 "Will not be able to guess NTSFUN from a parsed deck without TABDIMS."
             )
             logging.critical(
-                "Only data for first SATNUM will be returned. Instead, supply string to deck2df()"
+                (
+                    "Only data for first SATNUM will be returned."
+                    "Instead, supply string to deck2df()"
+                )
             )
             satnumcount = 1
         # If TABDIMS is in the deck, NTSFUN always has a value. It will
@@ -184,7 +187,7 @@ def fill_parser(parser):
     """Set up sys.argv parsers.
 
     Arguments:
-        parser (argparse.ArgumentParser or argparse.subparser): parser to fill with arguments
+        parser (ArgumentParser or subparser): parser to fill with arguments
     """
     parser.add_argument("DATAFILE", help="Name of Eclipse DATA file.")
     parser.add_argument(

--- a/ecl2df/satfunc2df.py
+++ b/ecl2df/satfunc2df.py
@@ -2,7 +2,16 @@
 # -*- coding: utf-8 -*-
 """
 Extract saturation function data (SWOF, SGOF, SWFN, ...)
-from an Eclipse deck as Pandas DataFrame
+from an Eclipse deck as Pandas DataFrame.
+
+Data can be extracted from a full Eclipse deck (*.DATA)
+or from individual files.
+
+Note that when parsing from individual files, it is
+undefined in the syntax how many saturation functions (SATNUMs) are
+present. For convenience, it is possible to estimate the count of
+SATNUMs, but whenever this is known, it is recommended to either supply
+TABDIMS or to supply the satnumcount directly to avoid possible bugs.
 
 """
 from __future__ import print_function
@@ -18,6 +27,9 @@ import sunbeam
 
 from .eclfiles import EclFiles
 
+# Dictionary of Eclipse keywords that holds saturation data, with
+# lists of which datatypes they contain. The datatypes/names will
+# be used as column headers in returned dataframes.
 KEYWORD_COLUMNS = {
     "SWOF": ["SW", "KRW", "KROW", "PCOW"],
     "SGOF": ["SG", "KRG", "KROG", "PCOG"],

--- a/ecl2df/satfunc2df.py
+++ b/ecl2df/satfunc2df.py
@@ -185,7 +185,11 @@ def deck2df(deck, satnumcount=None):
                 satnum += 1
                 frames.append(df)
 
-    return pd.concat(frames, axis=0, sort=False)
+    nonempty_frames = [frame for frame in frames if not frame.empty]
+    if nonempty_frames:
+        return pd.concat(nonempty_frames, axis=0, sort=False)
+    logging.warning("No saturation data found in deck")
+    return pd.DataFrame()
 
 
 def fill_parser(parser):
@@ -235,10 +239,11 @@ def satfunc2df_main(args):
         # more error-prone:
         stringdeck = "".join(open(args.DATAFILE).readlines())
         satfunc_df = deck2df(stringdeck)
-    logging.info(
-        "Unique satnums: %d, saturation keywords: %s",
-        satfunc_df["SATNUM"].unique(),
-        satfunc_df["KEYWORD"].unique(),
-    )
-    satfunc_df.to_csv(args.output, index=False)
-    print("Wrote to " + args.output)
+    if not satfunc_df.empty:
+        logging.info(
+            "Unique satnums: %d, saturation keywords: %s",
+            len(satfunc_df["SATNUM"].unique()),
+            str(satfunc_df["KEYWORD"].unique()),
+        )
+        satfunc_df.to_csv(args.output, index=False)
+        print("Wrote to " + args.output)

--- a/tests/test_satfunc2df.py
+++ b/tests/test_satfunc2df.py
@@ -48,6 +48,24 @@ SWOF
     assert len(satdf) == 2
 
 
+    swofstr2 = """
+SWOF
+ 0 0 1 1
+ 1 1 0 0
+/
+ 0 0 1 1
+ 0.5 0.5 0.5 0.5
+ 1 1 0 0
+/
+"""
+    deck2 = EclFiles.str2deck(swofstr2)
+    satdf2 = satfunc2df.deck2df(deck2)
+    print(satdf2)
+    assert 'SATNUM' in satdf
+    assert len(satdf['SATNUM'].unique()) == 2
+    assert len(satdf) == 2
+
+
 def test_main():
     """Test command line interface"""
     tmpcsvfile = ".TMP-satfunc.csv"

--- a/tests/test_satfunc2df.py
+++ b/tests/test_satfunc2df.py
@@ -47,7 +47,6 @@ SWOF
     satdf = satfunc2df.deck2df(deck)
     assert len(satdf) == 2
 
-
     swofstr2 = """
 -- RUNSPEC -- (this line is optional)
 
@@ -67,9 +66,43 @@ SWOF
 """
     deck2 = EclFiles.str2deck(swofstr2)
     satdf2 = satfunc2df.deck2df(deck2)
-    assert 'SATNUM' in satdf
-    assert len(satdf2['SATNUM'].unique()) == 2
+    assert "SATNUM" in satdf
+    assert len(satdf2["SATNUM"].unique()) == 2
     assert len(satdf2) == 5
+    sgofstr = """
+          SGOF
+             0 0 1 1
+                    1 1 0 0
+                           /
+       0 0 1 1
+                    0.5 0.5 0.5 0.5
+                 1 1 0 0
+      /
+                 0 0 1 0
+   0.1 0.1 0.1 0.1
+          1 1 0 0
+               /
+           """
+    sgofdf = satfunc2df.deck2df(EclFiles.str2deck(sgofstr))
+    assert 'SATNUM' in sgofdf
+    assert len(sgofdf["SATNUM"].unique()) == 3
+    assert len(sgofdf) == 8
+
+
+def test_injectsatnumcount():
+    """Test that we always get out a string with TABDIMS"""
+    assert "TABDIMS" in satfunc2df.inject_satnumcount("", 0)
+    assert "TABDIMS" in satfunc2df.inject_satnumcount("", 1)
+    assert "TABDIMS" in satfunc2df.inject_satnumcount("TABDIMS", 1)
+    assert "99" in satfunc2df.inject_satnumcount("", 99)
+
+
+def test_guess_satnumcount():
+    # We always require a newline after a "/" in the Eclipse syntax
+    assert satfunc2df.guess_satnumcount("SWOF\n0/\n0/\n") == 2
+    assert satfunc2df.guess_satnumcount("SWOF\n0/\n0/ \n0/\n") == 3
+    assert satfunc2df.guess_satnumcount("SWFN\n0/\n\n0/\n") == 2
+    assert satfunc2df.guess_satnumcount("SGOF\n0/\n") == 1
 
 
 def test_main():

--- a/tests/test_satfunc2df.py
+++ b/tests/test_satfunc2df.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Test module for nnc2df"""
+"""Test module for satfunc2df"""
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tests/test_satfunc2df.py
+++ b/tests/test_satfunc2df.py
@@ -70,6 +70,11 @@ SWOF
     assert len(satdf2["SATNUM"].unique()) == 2
     assert len(satdf2) == 5
 
+    # Try empty/bogus data:
+    bogusdf = satfunc2df.deck2df("SWRF\n 0 /\n")
+    # (warnings should be issued)
+    assert bogusdf.empty
+
 
 def test_sgof_satnuminferrer():
     sgofstr = """

--- a/tests/test_satfunc2df.py
+++ b/tests/test_satfunc2df.py
@@ -75,6 +75,17 @@ SWOF
     # (warnings should be issued)
     assert bogusdf.empty
 
+    # Test with bogus E100 keywords:
+    tricky = satfunc2df.deck2df("FOO\n\nSWOF\n 0 0 0 1/ 1 1 1 0\n/\n")
+    assert not tricky.empty
+    assert len(tricky["SATNUM"].unique()) == 1
+
+    # Test with unsupported (for OPM) E100 keywords (trickier than bogus..)
+    # # tricky = satfunc2df.deck2df("CARFIN\n\nSWOF\n 0 0 0 1/ 1 1 1 0\n/\n")
+    # # assert not tricky.empty
+    # # assert len(tricky["SATNUM"].unique()) == 1
+    # ### It remains unsolved how to avoid an error here!
+
 
 def test_sgof_satnuminferrer():
     sgofstr = """

--- a/tests/test_satfunc2df.py
+++ b/tests/test_satfunc2df.py
@@ -49,6 +49,13 @@ SWOF
 
 
     swofstr2 = """
+-- RUNSPEC -- (this line is optional)
+
+TABDIMS
+  2 /
+
+-- PROPS -- (optional)
+
 SWOF
  0 0 1 1
  1 1 0 0
@@ -60,10 +67,9 @@ SWOF
 """
     deck2 = EclFiles.str2deck(swofstr2)
     satdf2 = satfunc2df.deck2df(deck2)
-    print(satdf2)
     assert 'SATNUM' in satdf
-    assert len(satdf['SATNUM'].unique()) == 2
-    assert len(satdf) == 2
+    assert len(satdf2['SATNUM'].unique()) == 2
+    assert len(satdf2) == 5
 
 
 def test_main():


### PR DESCRIPTION
TABDIMS/NTSFUN can now be inferred/guessed.

This is done by trial-and-error, determined by when sunbeam fails.