### PR TITLE
Infer TABDIMS and EQLDIMS

### DIFF
--- a/ecl2df/inferdims.py
+++ b/ecl2df/inferdims.py
@@ -100,7 +100,7 @@ def inject_dimcount(deckstr, dimkeyword, dimitem, dimvalue):
         if dimitem not in [0, 1]:
             raise ValueError("Only support item 0 and 1 in TABDIMS")
     if dimkeyword == "EQLDIMS":
-        if item not in [0]:
+        if dimitem not in [0]:
             raise ValueError("Only item 0 in EQLDIMS can be estimated")
 
     if dimkeyword in deckstr:

--- a/ecl2df/inferdims.py
+++ b/ecl2df/inferdims.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""
+Support module for inferring EQLDIMS and TABDIMS from incomplete
+Eclipse 100 decks (typically single include-files)
+"""
+
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+import logging
+import sunbeam.deck
+
+from ecl2df import EclFiles
+
+
+def guess_dim(deckstring, dimkeyword, dimitem=0):
+    """Guess the correct dimension count for an incoming deck (string)
+
+    The incoming deck must in string form, if not, extra data is most
+    likely already removed by the sunbeam parser. TABDIMS or EQLDIMS
+    must not be present
+
+    This function will inject TABDIMS or EQLDIMS into it and reparse it in a
+    stricter mode, to detect the correct table dimensionality
+
+    Arguments:
+        deck (str): String containing an Eclipse deck or only a few Eclipse keywords
+        dimkeyword (str): Either TABDIMS or EQLDIMS
+        dimitem (int): The element number in TABDIMS/EQLDIMS to modify
+    Returns:
+        int: The lowest number for which stricter sunbeam parsing succeeds
+
+    """
+
+    if dimkeyword not in ["TABDIMS", "EQLDIMS"]:
+        raise ValueError("Only supports TABDIMS and EQLDIMS")
+    if dimkeyword == "TABDIMS":
+        if dimitem not in [0, 1]:
+            raise ValueError("Only support item 0 and 1 in TABDIMS")
+    if dimkeyword == "EQLDIMS":
+        if dimitem not in [0]:
+            raise ValueError("Only item 0 in EQLDIMS can be estimated")
+
+    # A less than ecl2df-standard permissive sunbeam, when using
+    # this one sunbeam will fail if there are extra records
+    # in tables (if NTSFUN in TABDIMS is wrong f.ex):
+    sunbeam_recovery_fail_extra_records = [
+        ("PARSE_UNKNOWN_KEYWORD", sunbeam.action.ignore),
+        ("SUMMARY_UNKNOWN_GROUP", sunbeam.action.ignore),
+        ("UNSUPPORTED_*", sunbeam.action.ignore),
+        ("PARSE_MISSING_SECTIONS", sunbeam.action.ignore),
+        ("PARSE_RANDOM_TEXT", sunbeam.action.ignore),
+        ("PARSE_MISSING_INCLUDE", sunbeam.action.ignore),
+    ]
+
+    max_guess = 640  # This ought to be enough for everybody
+    for dimcountguess in range(1, max_guess + 1):
+        deck_candidate = inject_dimcount(deckstring, dimkeyword, dimitem, dimcountguess)
+        try:
+            EclFiles.str2deck(
+                deck_candidate, recovery=sunbeam_recovery_fail_extra_records
+            )
+            # If we succeed, then the dimcountguess was correct
+            break
+        except ValueError:
+            # Typically we get the error PARSE_EXTRA_RECORDS because we did not guess
+            # high enough dimnumcount
+            continue
+            # If we get here, try another dimnumcount
+    if dimcountguess == max_guess:
+        logging.warning(
+            "Unable to guess dim count for %s, or larger than %d", dimkeyword, max_guess
+        )
+    logging.info(
+        "Guessed dimension count count for %s to %d", dimkeyword, dimcountguess
+    )
+    return dimcountguess
+
+
+def inject_dimcount(deckstr, dimkeyword, dimitem, dimvalue):
+    """Insert a TABDIMS with NTSFUN into a deck
+
+    This is simple string manipulation, not sunbeam
+    deck manipulation (which might be possible to do).
+
+    Arguments:
+        deckstr (str): A string containing a partial deck (f.ex only
+            the SWOF keyword).
+        dimkeyword (str): Either TABDIMS or EQLDIMS
+        dimitem (int): Item 0 (NTSSFUN) or 1 (NTPVT) of TABDIMS, only 0 for EQLDIMS.
+        dimvalue (int): The NTSFUN/NTPVT/NTEQUIL number to use
+            (this function does not care if it is correct or not)
+    Returns:
+        str: New deck with TABDIMS/EQLDIMS prepended.
+    """
+    if dimkeyword not in ["TABDIMS", "EQLDIMS"]:
+        raise ValueError("Only supports TABDIMS and EQLDIMS")
+    if dimkeyword == "TABDIMS":
+        if dimitem not in [0, 1]:
+            raise ValueError("Only support item 0 and 1 in TABDIMS")
+    if dimkeyword == "EQLDIMS":
+        if item not in [0]:
+            raise ValueError("Only item 0 in EQLDIMS can be estimated")
+
+    if dimkeyword in deckstr:
+        logging.warning("Not inserting %s in a deck where already exists", dimkeyword)
+        return deckstr
+    return (
+        dimkeyword
+        + "\n "
+        + int(dimitem) * "1* "
+        + str(dimvalue)
+        + " /\n\n"
+        + str(deckstr)
+    )

--- a/ecl2df/satfunc2df.py
+++ b/ecl2df/satfunc2df.py
@@ -25,6 +25,7 @@ import pandas as pd
 
 import sunbeam
 
+from ecl2df import inferdims
 from .eclfiles import EclFiles
 
 # Dictionary of Eclipse keywords that holds saturation data, with
@@ -100,7 +101,9 @@ def guess_satnumcount(deckstring):
 
     max_guess = 640  # This ought to be enough for everybody
     for satnumcountguess in range(1, max_guess + 1):
-        deck_candidate = inject_satnumcount(deckstring, satnumcountguess)
+        deck_candidate = inferdims.inject_dimcount(
+            deckstring, "TABDIMS", 0, satnumcountguess
+        )
         try:
             EclFiles.str2deck(
                 deck_candidate, recovery=sunbeam_recovery_fail_extra_records
@@ -165,12 +168,16 @@ def deck2df(deck, satnumcount=None):
                 "TABDIMS+NTSFUN or satnumcount not supplied. Will be guessed."
             )
             ntsfun_estimate = guess_satnumcount(deck)
-            augmented_strdeck = inject_satnumcount(str(deck), ntsfun_estimate)
+            augmented_strdeck = inferdims.inject_dimcount(
+                str(deck), "TABDIMS", 0, ntsfun_estimate
+            )
             # Re-parse the modified deck:
             deck = EclFiles.str2deck(augmented_strdeck)
 
         else:
-            augmented_strdeck = inject_satnumcount(str(deck), satnumcount)
+            augmented_strdeck = inferdims.inject_dimcount(
+                str(deck), "TABDIMS", 0, satnumcount
+            )
             # Re-parse the modified deck:
             deck = EclFiles.str2deck(augmented_strdeck)
 

--- a/tests/test_equil2df.py
+++ b/tests/test_equil2df.py
@@ -8,6 +8,8 @@ from __future__ import print_function
 import os
 import sys
 
+import pytest
+
 import pandas as pd
 
 from ecl2df import equil2df, ecl2csv
@@ -26,6 +28,7 @@ def test_equil2df():
 
 
 def test_decks():
+    """Test some string decks"""
     deckstr = """
 OIL
 WATER
@@ -81,6 +84,48 @@ EQUIL
     assert "OWC" not in df
     assert len(df) == 1
     assert "IGNORE2" not in df
+
+
+def test_ntequl():
+    """Test that we can infer NTEQUL when not supplied"""
+    deckstr = """
+GAS
+OIL
+
+EQUIL
+ 2000 200 2200 1 2100 3 /
+ 3000 200 2200 1 2100 3 /
+"""
+    df = equil2df.deck2df(deckstr)
+    assert set(df["GOC"].values) == set([2100, 2100])
+    assert len(df) == 2
+
+    # Supply correct NTEQUL instead of estimating
+    df = equil2df.deck2df(deckstr, 2)
+    assert len(df) == 2
+
+    # Supplying wrong NTEQUIL:
+    df = equil2df.deck2df(deckstr, 1)
+    # We are not able to catch this situation..
+    assert len(df) == 1
+    # But this will fail:
+    with pytest.raises(ValueError):
+        equil2df.deck2df(deckstr, 3)
+
+    deckstr = """
+GAS
+OIL
+
+EQLDIMS
+ 2 /
+
+EQUIL
+ 2000 200 2200 1 2100 3 /
+ 3000 200 2200 1 2100 3 /
+"""
+    df = equil2df.deck2df(deckstr)
+    assert set(df["GOC"].values) == set([2100, 2100])
+    assert len(df) == 2
 
 
 def test_main():

--- a/tests/test_inferdims.py
+++ b/tests/test_inferdims.py
@@ -15,6 +15,21 @@ def test_injectsatnumcount():
     assert "TABDIMS" in inferdims.inject_dimcount("TABDIMS", "TABDIMS", 0, 1)
     assert "99" in inferdims.inject_dimcount("", "TABDIMS", 0, 99)
 
+    assert " 1* " in inferdims.inject_dimcount("", "TABDIMS", 1, 99)
+    assert "*" not in inferdims.inject_dimcount("", "TABDIMS", 0, 99)
+
+    assert "EQLDIMS" in inferdims.inject_dimcount("", "EQLDIMS", 0, 0)
+    assert "EQLDIMS" in inferdims.inject_dimcount("", "EQLDIMS", 0, 1)
+    assert "EQLDIMS" in inferdims.inject_dimcount("EQLDIMS", "EQLDIMS", 0, 1)
+    assert "99" in inferdims.inject_dimcount("", "TABDIMS", 0, 99)
+
+
+def test_guess_ntequil():
+    """Test inferring the correct NTEQUIL"""
+    assert inferdims.guess_dim("EQUIL\n200 2000/\n2000 2000/\n", "EQLDIMS", 0) == 2
+    assert inferdims.guess_dim("EQUIL\n200 2000/\n", "EQLDIMS", 0) == 1
+    assert inferdims.guess_dim("EQUIL\n200 2000 333/\n0 0/\n1 1/\n", "EQLDIMS", 0) == 3
+
 
 def test_guess_satnumcount():
     # We always require a newline after a "/" in the Eclipse syntax

--- a/tests/test_inferdims.py
+++ b/tests/test_inferdims.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Test module for satfunc2df"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from ecl2df import inferdims
+
+
+def test_injectsatnumcount():
+    """Test that we always get out a string with TABDIMS"""
+    assert "TABDIMS" in inferdims.inject_dimcount("", "TABDIMS", 0, 0)
+    assert "TABDIMS" in inferdims.inject_dimcount("", "TABDIMS", 0, 1)
+    assert "TABDIMS" in inferdims.inject_dimcount("TABDIMS", "TABDIMS", 0, 1)
+    assert "99" in inferdims.inject_dimcount("", "TABDIMS", 0, 99)
+
+
+def test_guess_satnumcount():
+    # We always require a newline after a "/" in the Eclipse syntax
+    # (anything between a / and \n is ignored)
+    assert inferdims.guess_dim("SWOF\n0/\n0/\n", "TABDIMS", 0) == 2
+    assert inferdims.guess_dim("SWOF\n0/\n0/ \n0/\n", "TABDIMS", 0) == 3
+    assert inferdims.guess_dim("SWFN\n0/\n\n0/\n", "TABDIMS", 0) == 2
+    assert inferdims.guess_dim("SGOF\n0/\n", "TABDIMS", 0) == 1
+    assert inferdims.guess_dim("SGOF\n0/\n0/\n", "TABDIMS", 0) == 2
+    assert inferdims.guess_dim("SGOF\n0/\n0/\n0/\n", "TABDIMS", 0) == 3
+    assert (
+        inferdims.guess_dim("SGOF\n0 0 0 0/\n0 0 0 0/\n0 0 0 0/\n", "TABDIMS", 0) == 3
+    )
+    assert (
+        inferdims.guess_dim(
+            "SGOF\n0 0 0 0 1 1 1 1/\n0 0 0 0 1 1 1 1/\n0 0 0 0 1 1 1/\n", "TABDIMS", 0
+        )
+        == 3
+    )

--- a/tests/test_satfunc2df.py
+++ b/tests/test_satfunc2df.py
@@ -10,7 +10,7 @@ import sys
 
 import pandas as pd
 
-from ecl2df import satfunc2df, ecl2csv
+from ecl2df import satfunc2df, ecl2csv, inferdims
 from ecl2df.eclfiles import EclFiles
 
 TESTDIR = os.path.dirname(os.path.abspath(__file__))
@@ -122,32 +122,6 @@ SGOF
     ecl2csv.main()
     parsed_sgof = pd.read_csv(sgoffile + ".csv")
     assert len(parsed_sgof["SATNUM"].unique()) == 3
-
-
-def test_injectsatnumcount():
-    """Test that we always get out a string with TABDIMS"""
-    assert "TABDIMS" in satfunc2df.inject_satnumcount("", 0)
-    assert "TABDIMS" in satfunc2df.inject_satnumcount("", 1)
-    assert "TABDIMS" in satfunc2df.inject_satnumcount("TABDIMS", 1)
-    assert "99" in satfunc2df.inject_satnumcount("", 99)
-
-
-def test_guess_satnumcount():
-    # We always require a newline after a "/" in the Eclipse syntax
-    # (anything between a / and \n is ignored)
-    assert satfunc2df.guess_satnumcount("SWOF\n0/\n0/\n") == 2
-    assert satfunc2df.guess_satnumcount("SWOF\n0/\n0/ \n0/\n") == 3
-    assert satfunc2df.guess_satnumcount("SWFN\n0/\n\n0/\n") == 2
-    assert satfunc2df.guess_satnumcount("SGOF\n0/\n") == 1
-    assert satfunc2df.guess_satnumcount("SGOF\n0/\n0/\n") == 2
-    assert satfunc2df.guess_satnumcount("SGOF\n0/\n0/\n0/\n") == 3
-    assert satfunc2df.guess_satnumcount("SGOF\n0 0 0 0/\n0 0 0 0/\n0 0 0 0/\n") == 3
-    assert (
-        satfunc2df.guess_satnumcount(
-            "SGOF\n0 0 0 0 1 1 1 1/\n0 0 0 0 1 1 1 1/\n0 0 0 0 1 1 1/\n"
-        )
-        == 3
-    )
 
 
 def test_main():

--- a/tests/test_satfunc2df.py
+++ b/tests/test_satfunc2df.py
@@ -102,7 +102,7 @@ SGOF
   1 1 0 0
 /
 """
-    assert satfunc2df.guess_satnumcount(sgofstr) == 3
+    assert inferdims.guess_dim(sgofstr, "TABDIMS", 0) == 3
     sgofdf = satfunc2df.deck2df(sgofstr)
     assert "SATNUM" in sgofdf
     assert len(sgofdf["SATNUM"].unique()) == 3


### PR DESCRIPTION
Refactor to use a common module for inferring missing dimensionality data.

satfunc2df rewritten to use it, and equil2df modified to use it.

Prepared to also work for NTPVT (TABDIMS).

Solves #15 