### PR TITLE
Avoid AttributeError on py3 when ecl2csv is called with no args

### DIFF
--- a/ecl2df/ecl2csv.py
+++ b/ecl2df/ecl2csv.py
@@ -32,7 +32,9 @@ def get_parser():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
-    subparsers = parser.add_subparsers(parser_class=argparse.ArgumentParser)
+    subparsers = parser.add_subparsers(
+        required=True, parser_class=argparse.ArgumentParser
+    )
 
     # Eclipse output files:
     grid_parser = subparsers.add_parser(


### PR DESCRIPTION
This breaks the Py2 argparse API.