### PR TITLE
Fix for opm-common testing/2020.3/rc1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
 addons:
   apt:
     sources:
-      - boost-latest
       - ubuntu-toolchain-r-test
     packages:
       - libboost-all-dev

--- a/ecl2df/common.py
+++ b/ecl2df/common.py
@@ -96,7 +96,11 @@ def parse_opmio_deckrecord(
 
     for item_idx, jsonitem in enumerate(itemlist):
         item_name = jsonitem["name"]
-        if not record[item_idx].defaulted(0):
+        # Cleanup after 2020.03 for opm-common is released
+        # to not use the private property __defaulted
+        if not hasattr(record[item_idx], "__defaulted") or not record[
+            item_idx
+        ].__defaulted(0):
             rec_dict[item_name] = getattr(
                 record[item_idx], deckitem_fn[jsonitem["value_type"]]
             )(0)


### PR DESCRIPTION
opm-common's Python API is currently a moving target.