### PR TITLE
Fix bug in triggered in Py38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ python:
   - 2.7
   - 3.6
   - 3.7
+  - 3.8
 
 matrix:
     fast_finish: true

--- a/ecl2df/nnc.py
+++ b/ecl2df/nnc.py
@@ -60,7 +60,8 @@ def df(eclfiles, coords=False, pillars=False):
     )
     idx_cols1 = ["I1", "J1", "K1"]
     nnc1_df = pd.DataFrame(
-        columns=idx_cols1, data=[egrid_grid.get_ijk(global_index=x - 1) for x in nnc1]
+        columns=idx_cols1,
+        data=[egrid_grid.get_ijk(global_index=int(x) - 1) for x in nnc1],
     )
     # Returned indices from get_ijk are zero-based, convert to 1-based indices
     nnc1_df[idx_cols1] = nnc1_df[idx_cols1] + 1
@@ -75,7 +76,8 @@ def df(eclfiles, coords=False, pillars=False):
     )
     idx_cols2 = ["I2", "J2", "K2"]
     nnc2_df = pd.DataFrame(
-        columns=idx_cols2, data=[egrid_grid.get_ijk(global_index=x - 1) for x in nnc2]
+        columns=idx_cols2,
+        data=[egrid_grid.get_ijk(global_index=int(x) - 1) for x in nnc2],
     )
     nnc2_df[idx_cols2] = nnc2_df[idx_cols2] + 1
 


### PR DESCRIPTION
Iteration over vertical numpy vectors did not play
along with cwrap, an array([803], dtype=int32) must be
explicitly converted to the integer 803.