### PR TITLE
Fix bug with dependency on dataframe order for well segment

### DIFF
--- a/ecl2df/rft.py
+++ b/ecl2df/rft.py
@@ -235,10 +235,18 @@ def process_seg_topology(seg_data):
     in space, towards the sea.
 
     The last segment in a non-icd well gets the type TUBING.
+
+    Args:
+        seg_data (pd.DataFrame): Segment structure defined as a table with at least
+            the columns SEGIDX, SEGNXT
+
+    Returns:
+        pd.DataFrame: Augmented dataframe, extra columns and perhaps extra rows.
     """
     if not {"SEGIDX", "SEGNXT"}.issubset(set(seg_data.columns)):
         raise ValueError("Insufficient topology columns in dataframe")
 
+    seg_data = seg_data.sort_values("SEGIDX")
     # For the first segment, None is allowed as SEGNXT, which excludes
     # int as a  Pandas type. Convert to 0 for the moment
     seg_data["SEGNXT"] = seg_data["SEGNXT"].fillna(value=0).astype(int)

--- a/tests/test_rft.py
+++ b/tests/test_rft.py
@@ -287,6 +287,11 @@ def test_longer_branched_icd_well():
             "CONPRES": [291, 292, 392, 393],
         }
     )
+    seg_data = rft.process_seg_topology(wellseg)
+    assert sum(seg_data["LONELYSEG"]) == 4
+    assert sum(seg_data["LEAF"]) == 4
+    assert sum(seg_data["JUNCTION"]) == 6  # 1, 2 and 6 counted twice
+    assert sum(seg_data["LEAF"]) == 4
     (seg_data, icd_data) = rft.split_seg_icd(wellseg)
     print(rft.seg2dicttree(wellseg))
     print(rft.pretty_print_well(wellseg))


### PR DESCRIPTION
Now dataframe is always sorted on SEGIDX, as the merging procedures will behave differently
depending on row order. This renders the test with shuffling to a no-op, but kept as is.