### PR TITLE
Fix issues with WELOPEN and COMPDAT entries at the same date

### DIFF
--- a/ecl2df/compdat.py
+++ b/ecl2df/compdat.py
@@ -346,9 +346,7 @@ def applywelopen(compdat_df, welopen_df):
     if not compdat_df.empty:
         compdat_df = (
             compdat_df.sort_values(by=["KEYWORD_ID"])
-            .drop_duplicates(
-                subset=["I", "J", "K1", "K2", "DATE", "KEYWORD_ID"], keep="last"
-            )
+            .drop_duplicates(subset=["I", "J", "K1", "K2", "DATE"], keep="last")
             .reset_index(drop=True)
         )
 

--- a/ecl2df/compdat.py
+++ b/ecl2df/compdat.py
@@ -140,7 +140,6 @@ def deck2dfs(deck, start_date=None, unroll=True):
                 )
                 if "INFO_TYPE" in rec_data and rec_data["INFO_TYPE"] == "ABS":
                     rec_data["SEGMENT_MD"] = rec_data["SEGMENT_LENGTH"]
-
                 welsegsrecords.append(rec_data)
 
     compdat_df = pd.DataFrame(compdatrecords)

--- a/ecl2df/compdat.py
+++ b/ecl2df/compdat.py
@@ -93,7 +93,7 @@ def deck2dfs(deck, start_date=None, unroll=True):
                     rec, "COMPDAT", renamer=COMPDAT_RENAMER
                 )
                 rec_data["DATE"] = date
-                rec_data["KEYWORD_ID"] = idx
+                rec_data["KEYWORD_IDX"] = idx
                 compdatrecords.append(rec_data)
         elif kword.name == "COMPSEGS":
             wellname = parse_opmio_deckrecord(
@@ -111,7 +111,7 @@ def deck2dfs(deck, start_date=None, unroll=True):
             for rec in kword:
                 rec_data = parse_opmio_deckrecord(rec, "WELOPEN")
                 rec_data["DATE"] = date
-                rec_data["KEYWORD_ID"] = idx
+                rec_data["KEYWORD_IDX"] = idx
                 if rec_data["STATUS"] not in ["OPEN", "SHUT", "STOP", "AUTO"]:
                     rec_data["STATUS"] = "SHUT"
                     logger.warning(
@@ -157,8 +157,8 @@ def deck2dfs(deck, start_date=None, unroll=True):
     if unroll and not welsegs_df.empty:
         welsegs_df = unrolldf(welsegs_df, "SEGMENT1", "SEGMENT2")
 
-    if "KEYWORD_ID" in compdat_df.columns:
-        compdat_df.drop(["KEYWORD_ID"], axis=1, inplace=True)
+    if "KEYWORD_IDX" in compdat_df.columns:
+        compdat_df.drop(["KEYWORD_IDX"], axis=1, inplace=True)
 
     return dict(COMPDAT=compdat_df, COMPSEGS=compsegs_df, WELSEGS=welsegs_df)
 
@@ -299,7 +299,7 @@ def applywelopen(compdat_df, welopen_df):
         if row["I"] and row["J"] and row["K"]:
             previous_state = compdat_df[
                 (compdat_df["WELL"] == row["WELL"])
-                & (compdat_df["KEYWORD_ID"] < row["KEYWORD_ID"])
+                & (compdat_df["KEYWORD_IDX"] < row["KEYWORD_IDX"])
                 & (compdat_df["I"] == row["I"])
                 & (compdat_df["J"] == row["J"])
                 & (compdat_df["K1"] == row["K"])
@@ -315,7 +315,7 @@ def applywelopen(compdat_df, welopen_df):
         elif not (row["I"] and row["J"] and row["K"]):
             previous_state = compdat_df[
                 (compdat_df["WELL"] == row["WELL"])
-                & (compdat_df["KEYWORD_ID"] < row["KEYWORD_ID"])
+                & (compdat_df["KEYWORD_IDX"] < row["KEYWORD_IDX"])
             ].drop_duplicates(subset=["I", "J", "K1", "K2"], keep="last")
         else:
             raise ValueError(
@@ -338,14 +338,14 @@ def applywelopen(compdat_df, welopen_df):
         # well in COMPDAT and WELOPEN are not identical. These translation steps can
         # be dropped when unity in the opm-common keyword definitions is reached.
         new_state["OP/SH"] = row["STATUS"]
-        new_state["KEYWORD_ID"] = row["KEYWORD_ID"]
+        new_state["KEYWORD_IDX"] = row["KEYWORD_IDX"]
         new_state["DATE"] = row["DATE"]
 
         compdat_df = compdat_df.append(new_state)
 
     if not compdat_df.empty:
         compdat_df = (
-            compdat_df.sort_values(by=["KEYWORD_ID"])
+            compdat_df.sort_values(by=["KEYWORD_IDX"])
             .drop_duplicates(subset=["I", "J", "K1", "K2", "DATE"], keep="last")
             .reset_index(drop=True)
         )

--- a/ecl2df/compdat.py
+++ b/ecl2df/compdat.py
@@ -70,7 +70,7 @@ def deck2dfs(deck, start_date=None, unroll=True):
     welopenrecords = []
     welsegsrecords = []
     date = start_date  # DATE column will always be there, but can contain NaN/None
-    for kword in deck:
+    for idx, kword in enumerate(deck):
         if kword.name == "DATES" or kword.name == "START":
             for rec in kword:
                 date = parse_opmio_date_rec(rec)
@@ -93,6 +93,7 @@ def deck2dfs(deck, start_date=None, unroll=True):
                     rec, "COMPDAT", renamer=COMPDAT_RENAMER
                 )
                 rec_data["DATE"] = date
+                rec_data["KEYWORD_ID"] = idx
                 compdatrecords.append(rec_data)
         elif kword.name == "COMPSEGS":
             wellname = parse_opmio_deckrecord(
@@ -110,6 +111,7 @@ def deck2dfs(deck, start_date=None, unroll=True):
             for rec in kword:
                 rec_data = parse_opmio_deckrecord(rec, "WELOPEN")
                 rec_data["DATE"] = date
+                rec_data["KEYWORD_ID"] = idx
                 if rec_data["STATUS"] not in ["OPEN", "SHUT", "STOP", "AUTO"]:
                     rec_data["STATUS"] = "SHUT"
                     logger.warning(
@@ -138,6 +140,7 @@ def deck2dfs(deck, start_date=None, unroll=True):
                 )
                 if "INFO_TYPE" in rec_data and rec_data["INFO_TYPE"] == "ABS":
                     rec_data["SEGMENT_MD"] = rec_data["SEGMENT_LENGTH"]
+
                 welsegsrecords.append(rec_data)
 
     compdat_df = pd.DataFrame(compdatrecords)
@@ -154,6 +157,9 @@ def deck2dfs(deck, start_date=None, unroll=True):
 
     if unroll and not welsegs_df.empty:
         welsegs_df = unrolldf(welsegs_df, "SEGMENT1", "SEGMENT2")
+
+    if "KEYWORD_ID" in compdat_df.columns:
+        compdat_df.drop(["KEYWORD_ID"], axis=1, inplace=True)
 
     return dict(COMPDAT=compdat_df, COMPSEGS=compsegs_df, WELSEGS=welsegs_df)
 
@@ -294,7 +300,7 @@ def applywelopen(compdat_df, welopen_df):
         if row["I"] and row["J"] and row["K"]:
             previous_state = compdat_df[
                 (compdat_df["WELL"] == row["WELL"])
-                & (compdat_df["DATE"] <= row["DATE"])
+                & (compdat_df["KEYWORD_ID"] < row["KEYWORD_ID"])
                 & (compdat_df["I"] == row["I"])
                 & (compdat_df["J"] == row["J"])
                 & (compdat_df["K1"] == row["K"])
@@ -310,7 +316,7 @@ def applywelopen(compdat_df, welopen_df):
         elif not (row["I"] and row["J"] and row["K"]):
             previous_state = compdat_df[
                 (compdat_df["WELL"] == row["WELL"])
-                & (compdat_df["DATE"] <= row["DATE"])
+                & (compdat_df["KEYWORD_ID"] < row["KEYWORD_ID"])
             ].drop_duplicates(subset=["I", "J", "K1", "K2"], keep="last")
         else:
             raise ValueError(
@@ -333,15 +339,17 @@ def applywelopen(compdat_df, welopen_df):
         # well in COMPDAT and WELOPEN are not identical. These translation steps can
         # be dropped when unity in the opm-common keyword definitions is reached.
         new_state["OP/SH"] = row["STATUS"]
-
+        new_state["KEYWORD_ID"] = row["KEYWORD_ID"]
         new_state["DATE"] = row["DATE"]
 
         compdat_df = compdat_df.append(new_state)
 
     if not compdat_df.empty:
         compdat_df = (
-            compdat_df.sort_values(by=["DATE", "WELL"])
-            .drop_duplicates(subset=["I", "J", "K1", "K2", "DATE"], keep="last")
+            compdat_df.sort_values(by=["KEYWORD_ID"])
+            .drop_duplicates(
+                subset=["I", "J", "K1", "K2", "DATE", "KEYWORD_ID"], keep="last"
+            )
             .reset_index(drop=True)
         )
 

--- a/tests/test_compdat.py
+++ b/tests/test_compdat.py
@@ -214,7 +214,7 @@ WELOPEN
 /
 """
     df = compdat.deck2dfs(EclFiles.str2deck(schstr))["COMPDAT"]
-    assert df.shape[0] == 6
+    assert df.shape[0] == 5
     assert df["OP/SH"].nunique() == 2
     assert df["DATE"].nunique() == 3
 

--- a/tests/test_compdat.py
+++ b/tests/test_compdat.py
@@ -214,7 +214,7 @@ WELOPEN
 /
 """
     df = compdat.deck2dfs(EclFiles.str2deck(schstr))["COMPDAT"]
-    assert df.shape[0] == 5
+    assert df.shape[0] == 6
     assert df["OP/SH"].nunique() == 2
     assert df["DATE"].nunique() == 3
 

--- a/tests/test_welopen.py
+++ b/tests/test_welopen.py
@@ -294,9 +294,9 @@ WELOPEN_CASES = [
                 "WELL": {0: "OP1", 1: "OP1"},
                 "I": {0: 1, 1: 1},
                 "J": {0: 1, 1: 1},
-                "K1": {0: 1, 1: 2},
-                "K2": {0: 1, 1: 2},
-                "OP/SH": {0: "SHUT", 1: "OPEN"},
+                "K1": {0: 2, 1: 1},
+                "K2": {0: 2, 1: 1},
+                "OP/SH": {0: "OPEN", 1: "SHUT"},
                 "DATE": {0: datetime.date(2001, 5, 1), 1: datetime.date(2001, 5, 1)},
             }
         ),
@@ -331,6 +331,60 @@ WELOPEN_CASES = [
             }
         ),
     ),
+    (
+        """
+    DATES
+     1 MAY 2001 /
+    /
+
+    COMPDAT
+     'OP1' 1 1 1 1 'OPEN'  /
+    /
+
+    WELOPEN
+     'OP1' 'OPEN' /
+     'OP1' 'SHUT' /
+    /
+    """,
+        pd.DataFrame(
+            {
+                "WELL": {0: "OP1"},
+                "I": {0: 1},
+                "J": {0: 1},
+                "K1": {0: 1},
+                "K2": {0: 1},
+                "OP/SH": {0: "SHUT"},
+                "DATE": {0: datetime.date(2001, 5, 1)},
+            }
+        ),
+    ),
+    (
+        """
+    DATES
+     1 MAY 2001 /
+    /
+
+    COMPDAT
+     'OP1' 1 1 1 2 'SHUT'  /
+    /
+
+    WELOPEN
+     'OP1' 'OPEN' /
+     'OP1' 'SHUT' 1 1 1 /
+    /
+    """,
+        pd.DataFrame(
+            {
+                "WELL": {0: "OP1", 1: "OP1"},
+                "I": {0: 1, 1: 1},
+                "J": {0: 1, 1: 1},
+                "K1": {0: 2, 1: 1},
+                "K2": {0: 2, 1: 1},
+                "OP/SH": {0: "OPEN", 1: "SHUT"},
+                "DATE": {0: datetime.date(2001, 5, 1), 1: datetime.date(2001, 5, 1)},
+            }
+        ),
+    ),
 ]
 
 
@@ -341,4 +395,4 @@ def test_welopen(test_input, expected):
     compdf = compdat.deck2dfs(deck)["COMPDAT"]
 
     columns_to_check = ["WELL", "I", "J", "K1", "K2", "OP/SH", "DATE"]
-    assert all(compdf[columns_to_check] == expected[columns_to_check])
+    assert (compdf[columns_to_check] == expected[columns_to_check]).all(axis=None)

--- a/tests/test_welopen.py
+++ b/tests/test_welopen.py
@@ -237,9 +237,7 @@ WELOPEN_CASES = [
                 "K1": {0: 1},
                 "K2": {0: 1},
                 "OP/SH": {0: "SHUT"},
-                "DATE": {
-                    0: datetime.date(2001, 5, 1)
-                },
+                "DATE": {0: datetime.date(2001, 5, 1)},
             }
         ),
     ),
@@ -272,11 +270,8 @@ WELOPEN_CASES = [
                 "J": {0: 1, 1: 1},
                 "K1": {0: 1, 1: 1},
                 "K2": {0: 1, 1: 1},
-                "OP/SH": {0: "OPEN",1 : "OPEN"},
-                "DATE": {
-                    0: datetime.date(2001, 5, 1),
-                    1: datetime.date(2001, 5, 2)
-                },
+                "OP/SH": {0: "OPEN", 1: "OPEN"},
+                "DATE": {0: datetime.date(2001, 5, 1), 1: datetime.date(2001, 5, 2)},
             }
         ),
     ),

--- a/tests/test_welopen.py
+++ b/tests/test_welopen.py
@@ -215,6 +215,71 @@ WELOPEN_CASES = [
             }
         ),
     ),
+    (
+        """
+    DATES
+     1 MAY 2001 /
+    /
+
+    COMPDAT
+     'OP1' 1 1 1 1 'OPEN'  /
+    /
+
+    WELOPEN
+     'OP1' 'SHUT' /
+    /
+    """,
+        pd.DataFrame(
+            {
+                "WELL": {0: "OP1"},
+                "I": {0: 1},
+                "J": {0: 1},
+                "K1": {0: 1},
+                "K2": {0: 1},
+                "OP/SH": {0: "SHUT"},
+                "DATE": {
+                    0: datetime.date(2001, 5, 1)
+                },
+            }
+        ),
+    ),
+    (
+        """
+    DATES
+     1 MAY 2001 /
+    /
+    
+    COMPDAT
+     'OP1' 1 1 1 1 'OPEN'  /
+    /
+    
+    DATES
+     2 MAY 2001 /
+    /
+
+    WELOPEN
+     'OP1' 'SHUT' /
+    /
+
+    COMPDAT
+     'OP1' 1 1 1 1 'OPEN'  /
+    /
+    """,
+        pd.DataFrame(
+            {
+                "WELL": {0: "OP1", 1: "OP1"},
+                "I": {0: 1, 1: 1},
+                "J": {0: 1, 1: 1},
+                "K1": {0: 1, 1: 1},
+                "K2": {0: 1, 1: 1},
+                "OP/SH": {0: "OPEN",1 : "OPEN"},
+                "DATE": {
+                    0: datetime.date(2001, 5, 1),
+                    1: datetime.date(2001, 5, 2)
+                },
+            }
+        ),
+    ),
 ]
 
 

--- a/tests/test_welopen.py
+++ b/tests/test_welopen.py
@@ -246,11 +246,11 @@ WELOPEN_CASES = [
     DATES
      1 MAY 2001 /
     /
-    
+
     COMPDAT
      'OP1' 1 1 1 1 'OPEN'  /
     /
-    
+
     DATES
      2 MAY 2001 /
     /
@@ -272,6 +272,62 @@ WELOPEN_CASES = [
                 "K2": {0: 1, 1: 1},
                 "OP/SH": {0: "OPEN", 1: "OPEN"},
                 "DATE": {0: datetime.date(2001, 5, 1), 1: datetime.date(2001, 5, 2)},
+            }
+        ),
+    ),
+    (
+        """
+    DATES
+     1 MAY 2001 /
+    /
+
+    COMPDAT
+     'OP1' 1 1 1 2 'OPEN'  /
+    /
+
+    WELOPEN
+     'OP1' 'SHUT' 1 1 1 /
+    /
+    """,
+        pd.DataFrame(
+            {
+                "WELL": {0: "OP1", 1: "OP1"},
+                "I": {0: 1, 1: 1},
+                "J": {0: 1, 1: 1},
+                "K1": {0: 1, 1: 2},
+                "K2": {0: 1, 1: 2},
+                "OP/SH": {0: "SHUT", 1: "OPEN"},
+                "DATE": {0: datetime.date(2001, 5, 1), 1: datetime.date(2001, 5, 1)},
+            }
+        ),
+    ),
+    (
+        """
+    DATES
+     1 MAY 2001 /
+    /
+
+    COMPDAT
+     'OP1' 1 1 1 1 'OPEN'  /
+    /
+
+    WELOPEN
+     'OP1' 'SHUT' /
+    /
+
+    WELOPEN
+     'OP1' 'OPEN' /
+    /
+    """,
+        pd.DataFrame(
+            {
+                "WELL": {0: "OP1"},
+                "I": {0: 1},
+                "J": {0: 1},
+                "K1": {0: 1},
+                "K2": {0: 1},
+                "OP/SH": {0: "OPEN"},
+                "DATE": {0: datetime.date(2001, 5, 1)},
             }
         ),
     ),


### PR DESCRIPTION
`WELOPEN` previously would have overwritten all actions in at the current date; now, the order of the keywords inside of the date-block dictates what happens as it would in a simulation run.

The following SCHEDULE section,
```
DATES
 x x x /

WELOPEN
 OP1 SHUT /
/
COMPDAT
 OP1 1 1 1 OPEN /
/
```
now produces one `COMPDAT` line with `OPEN` instead of `SHUT` one.

