### PR TITLE
Adapt to be used directly with fmu-ensemble

### DIFF
--- a/ecl2df/eclfiles.py
+++ b/ecl2df/eclfiles.py
@@ -146,7 +146,15 @@ class EclFiles(object):
                     errno.ENOENT, os.strerror(errno.ENOENT), smryfilename
                 )
             logger.info("Opening UNSMRY file: %s", smryfilename)
-            self._eclsum = EclSum(smryfilename, include_restart=include_restart)
+            try:
+                self._eclsum = EclSum(smryfilename, include_restart=include_restart)
+            except IOError:
+                # This can happen if there is something wrong with the file
+                # or if SMSPEC is missing.
+                logger.warning(
+                    "Failed to create summary instance from %s", smryfilename
+                )
+                return None
         return self._eclsum
 
     def get_initfile(self):

--- a/ecl2df/eclfiles.py
+++ b/ecl2df/eclfiles.py
@@ -146,15 +146,7 @@ class EclFiles(object):
                     errno.ENOENT, os.strerror(errno.ENOENT), smryfilename
                 )
             logger.info("Opening UNSMRY file: %s", smryfilename)
-            try:
-                self._eclsum = EclSum(smryfilename, include_restart=include_restart)
-            except IOError:
-                # This can happen if there is something wrong with the file
-                # or if SMSPEC is missing.
-                logger.warning(
-                    "Failed to create summary instance from %s", smryfilename
-                )
-                return None
+            self._eclsum = EclSum(smryfilename, include_restart=include_restart)
         return self._eclsum
 
     def get_initfile(self):

--- a/ecl2df/summary.py
+++ b/ecl2df/summary.py
@@ -46,29 +46,6 @@ def date_range(start_date, end_date, freq):
     return pd.date_range(start_date, end_date, freq=PD_FREQ_MNEMONICS.get(freq, freq))
 
 
-def normalize_dates(start_date, end_date, freq):
-    """
-    Normalize start and end date according to frequency
-    by extending the time range.
-
-    So for [1997-11-05, 2020-03-02] and monthly frequency
-    this will transform your dates to
-    [1997-11-01, 2020-04-01]
-
-    For yearly frequency it will return [1997-01-01, 2021-01-01].
-
-    Args:
-        start_date: datetime.date
-        end_date: datetime.date
-        freq: string with either 'monthly' or 'yearly'.
-            Anything else will return the input as is
-    Return:
-        Tuple of normalized (start_date, end_date)
-    """
-    offset = pd.tseries.frequencies.to_offset(PD_FREQ_MNEMONICS.get(freq, freq))
-    return (offset.rollback(start_date).date(), offset.rollforward(end_date).date())
-
-
 def _ensure_date_or_none(some_date):
     """Ensures an object is either a date or None
 
@@ -174,7 +151,13 @@ def resample_smry_dates(
     start_smry = min(eclsumsdates)
     end_smry = max(eclsumsdates)
 
-    (start_n, end_n) = normalize_dates(start_smry.date(), end_smry.date(), freq)
+    # Normalize start and end date according to frequency by extending the time range.
+    # [1997-11-05, 2020-03-02] and monthly frequecy
+    # will be mapped to [1997-11-01, 2020-04-01]
+    # For yearly frequency it will return [1997-01-01, 2021-01-01].
+    offset = pd.tseries.frequencies.to_offset(PD_FREQ_MNEMONICS.get(freq, freq))
+    start_n = offset.rollback(start_smry.date()).date()
+    end_n = offset.rollforward(end_smry.date()).date()
 
     if not start_date and not normalize:
         start_date_range = start_smry.date()

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -588,7 +588,10 @@ def test_ecl2df_errors(tmpdir):
 
     # But EclFiles should be more tolerant, as it should be possible
     # to extract other data if SMRY is corrupted
-    assert EclFiles("FOO").get_eclsum() is None  # (a warning is printed)
+    Path("FOO.DATA").write_text("RUNSPEC")
+    assert str(EclFiles("FOO").get_ecldeck()).strip() == "RUNSPEC"
+    with pytest.raises(OSError):
+        EclFiles("FOO").get_eclsum()
 
     # Getting a dataframe from bogus data should give empty data:
     assert df(EclFiles("FOO")).empty

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -17,7 +17,6 @@ import ecl
 from ecl2df import summary, ecl2csv, csv2ecl
 from ecl2df.eclfiles import EclFiles
 from ecl2df.summary import (
-    normalize_dates,
     resample_smry_dates,
     df2eclsum,
     df,
@@ -222,28 +221,6 @@ def test_main_subparser(tmpdir):
 def test_datenormalization():
     """Test normalization of dates, where
     dates can be ensured to be on dategrid boundaries"""
-
-    start = datetime.date(1997, 11, 5)
-    end = datetime.date(2020, 3, 2)
-
-    assert normalize_dates(start, end, "monthly") == (
-        datetime.date(1997, 11, 1),
-        datetime.date(2020, 4, 1),
-    )
-    assert normalize_dates(start, end, "yearly") == (
-        datetime.date(1997, 1, 1),
-        datetime.date(2021, 1, 1),
-    )
-
-    # Check it does not touch already aligned dates
-    assert normalize_dates(
-        datetime.date(1997, 11, 1), datetime.date(2020, 4, 1), "monthly"
-    ) == (datetime.date(1997, 11, 1), datetime.date(2020, 4, 1))
-    assert normalize_dates(
-        datetime.date(1997, 1, 1), datetime.date(2021, 1, 1), "yearly"
-    ) == (datetime.date(1997, 1, 1), datetime.date(2021, 1, 1))
-
-    # Check that we normalize correctly with get_smry():
     # realization-0 here has its last summary date at 2003-01-02
     eclfiles = EclFiles(DATAFILE)
     daily = summary.df(eclfiles, column_keys="FOPT", time_index="daily", datetime=True)
@@ -256,11 +233,6 @@ def test_datenormalization():
         eclfiles, column_keys="FOPT", time_index="yearly", datetime=True
     )
     assert str(yearly.index[-1])[0:10] == "2004-01-01"
-
-    # Map a tuesday-thursday range to monday-nextmonday:
-    assert normalize_dates(
-        datetime.date(2020, 11, 17), datetime.date(2020, 11, 19), "weekly"
-    ) == (datetime.date(2020, 11, 16), datetime.date(2020, 11, 23))
 
 
 def test_resample_smry_dates():

--- a/tests/test_userapi.py
+++ b/tests/test_userapi.py
@@ -30,7 +30,7 @@ def test_userapi():
     pillars = ecl2df.pillars.df(eclfiles)
     rft = ecl2df.rft.df(eclfiles)
     satfunc = ecl2df.satfunc.df(eclfiles)
-    smry = ecl2df.summary.df(eclfiles)
+    smry = ecl2df.summary.df(eclfiles, datetime=True)
     trans = ecl2df.trans.df(eclfiles)
     wcon = ecl2df.wcon.df(eclfiles)
 


### PR DESCRIPTION
Based on what is needed to pass tests in fmu-ensemble

Necessary for able https://github.com/equinor/fmu-ensemble/issues/166

 * [x] Tests for the changes in ecl2df must be transferred from fmu-ensemble's test suite.
 * [x] Pylinting

Bonus changes:
* Deprecate non-datetime-index as return type from `df()`
* Refactor/deletion for code readability, normalize_dates() has been removed (the function is assumed to be private)