### PR TITLE
Add numpy to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ REQUIREMENTS = [
     "ecl",
     "equinor-libres",
     "ert",
+    "numpy",
     "opm",
     "pandas",
     "pyyaml>=5.1",


### PR DESCRIPTION
There are lines with `import numpy as np` in `ecl2df`, and it should thus be declared as a direct dependency, not only piggybacking pandas.