### PR TITLE
Add RTEMP to test deck

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ REQUIREMENTS = [
     "equinor-libres",
     "ert",
     "numpy",
-    "opm",
+    "opm>=2020.10.2",  # NB: Pypi versions.
     "pandas",
     "pyyaml>=5.1",
     "treelib",

--- a/tests/data/reek/eclipse/model/2_R001_REEK-0.DATA
+++ b/tests/data/reek/eclipse/model/2_R001_REEK-0.DATA
@@ -229,6 +229,9 @@ EQUALS
 -------------------------------------------------------------------------
 
 SOLUTION
+
+RTEMP
+ 100 /
   
 INCLUDE                                
 '../include/solution/reek.equil' /    


### PR DESCRIPTION
This requires OPM-common >= 2020.10 (>= 2020.10.2 on pypi)

Proves #210 is fixed.