### PR TITLE
Add __init__ to tests, resolve codecoverage issue

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,7 +3,7 @@ import subprocess
 
 import pytest
 
-from test_grid import DATAFILE
+from .test_grid import DATAFILE
 
 
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="Requires Python 3.7 or higher")


### PR DESCRIPTION
Should solve zero coverage issue, ref. similar PR in pyscal.