### PR TITLE
Refactor pretty-printing of trees without breaking API

### DIFF
--- a/ecl2df/gruptree.py
+++ b/ecl2df/gruptree.py
@@ -240,7 +240,7 @@ def _sub_tree_from_dict(nested_dict, name):
 
 
 def tree_from_dict(nested_dict):
-    """Convert a dictonary to a treelib Tree
+    """Convert a dictonary to a treelib Tree.
 
     The treelib representation of the trees is used
     for pretty-printing (in ASCII) of the tree, you
@@ -326,7 +326,7 @@ def fill_parser(parser):
 
 
 def gruptree_main(args):
-    """Entry-point for module, for command line utility"""
+    """Entry-point for module, for command line utility."""
     if args.verbose:
         logging.basicConfig(level=logging.INFO)
     if not args.output and not args.prettyprint:

--- a/ecl2df/gruptree.py
+++ b/ecl2df/gruptree.py
@@ -255,10 +255,14 @@ def tree_from_dict(nested_dict):
     Returns:
         treelib.Tree
     """
-    if not nested_dict:
+    if not nested_dict.keys():
         # Return an empty string, because str(treelib.Tree()) will error
         return ""
-    assert len(nested_dict.keys()) == 1, "One tree at a time please"
+    if not len(nested_dict.keys()) == 1:
+        raise ValueError(
+            "The dict given to tree_from_dict() must have "
+            "exactly one top level key, representing a single tree."
+        )
     root_name = list(nested_dict.keys())[0]
     return _sub_tree_from_dict(nested_dict[root_name], root_name)
 

--- a/ecl2df/gruptree.py
+++ b/ecl2df/gruptree.py
@@ -226,21 +226,15 @@ def edge_dataframe2dict(dframe):
     return [{root: subtrees[root]} for root in sorted(roots)]
 
 
-def _sub_tree_from_dict(nested_dict, name):
-    """Internal recursive function for generating trees."""
+def _add_to_tree_from_dict(nested_dict, name, tree, parent=None):
     assert isinstance(nested_dict, dict)
-    tree = treelib.Tree()
-    tree.create_node(name, name)
-    child_names = list(nested_dict.keys())
-    child_names.sort()
-    for child_name in child_names:
-        # The paste() function requires unique node names.
-        tree.paste(name, _sub_tree_from_dict(nested_dict[child_name], child_name))
-    return tree
+    tree.create_node(name, name, parent=parent)
+    for key, value in sorted(nested_dict.items()):
+        _add_to_tree_from_dict(nested_dict=value, name=key, tree=tree, parent=name)
 
 
 def tree_from_dict(nested_dict):
-    """Convert a dictonary to a treelib Tree.
+    """Convert a dictionary to a treelib Tree.
 
     The treelib representation of the trees is used
     for pretty-printing (in ASCII) of the tree, you
@@ -264,7 +258,9 @@ def tree_from_dict(nested_dict):
             "exactly one top level key, representing a single tree."
         )
     root_name = list(nested_dict.keys())[0]
-    return _sub_tree_from_dict(nested_dict[root_name], root_name)
+    tree = treelib.Tree()
+    _add_to_tree_from_dict(nested_dict[root_name], root_name, tree)
+    return tree
 
 
 def dict2treelib(name, nested_dict):

--- a/ecl2df/rft.py
+++ b/ecl2df/rft.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 
 from .eclfiles import EclFiles
-from .gruptree import dict2treelib
+from .gruptree import tree_from_dict
 from .common import merge_zones, write_dframe_stdout_file
 
 
@@ -324,7 +324,7 @@ def pretty_print_well(seg_data):
         str (multiline)
     """
     dicttree = seg2dicttree(seg_data)
-    return str(dict2treelib("SEGIDX", dicttree))
+    return str(tree_from_dict(dicttree))
 
 
 def split_seg_icd(seg_data):

--- a/tests/test_gruptree.py
+++ b/tests/test_gruptree.py
@@ -329,8 +329,12 @@ def test_multiple_roots():
     )
     assert gruptree.edge_dataframe2dict(edges_noroots) == answer
 
+    # The function tree_from_dict should be called with one tree at a time:
+    with pytest.raises(ValueError, match="single tree"):
+        gruptree.tree_from_dict({"foo": 1, "bar": 2})
 
-def test_emptytree(tmpdir, mocker, caplog):
+
+def test_emptytree_strdeck():
     """Test empty schedule sections. Don't want to crash"""
     schstr = ""
     deck = EclFiles.str2deck(schstr)
@@ -344,6 +348,8 @@ def test_emptytree(tmpdir, mocker, caplog):
     # a workaround for a limitation in treelib.
     assert treelibtree == ""
 
+
+def test_emptytree_commandlinetool(tmpdir, mocker, caplog):
     tmpdir.chdir()
     Path("EMPTY.DATA").write_text("")
     mocker.patch("sys.argv", ["ecl2csv", "gruptree", "--prettyprint", "EMPTY.DATA"])


### PR DESCRIPTION
Replaces #236, changing function name, and keeping old function with a ~DeprecationWarning~ FutureWarning.

Improved testing of tree stringification

Bugfix in edge_dataframe2dict on multiple roots.

Kudos to lgtm.com for exposing the problem in an alert.