### PR TITLE
Fix sphinx-argparse for csv2ecl

### DIFF
--- a/docs/csv2ecl.rst
+++ b/docs/csv2ecl.rst
@@ -1,17 +1,3 @@
-ecl2csv
-=======
-
-Most of the functionality in ecl2df is exposed to the command line through
-the script *ecl2csv*. The first argument to this script is always
-the submodule (subcommand) from which you want functionality. Mandatory argument is
-always an Eclipse deck or sometimes individual Eclipse include files, and
-there is usually an ``--output`` option to specify which file to dump
-the CSV to. If you want output to your terminal, use ``-`` as the output filename.
-
-.. argparse::
-   :ref: ecl2df.ecl2csv.get_parser
-   :prog: ecl2csv
-
 csv2ecl
 =======
 

--- a/docs/ecl2csv.rst
+++ b/docs/ecl2csv.rst
@@ -1,0 +1,13 @@
+ecl2csv
+=======
+
+Most of the functionality in ecl2df is exposed to the command line through
+the script *ecl2csv*. The first argument to this script is always
+the submodule (subcommand) from which you want functionality. Mandatory argument is
+always an Eclipse deck or sometimes individual Eclipse include files, and
+there is usually an ``--output`` option to specify which file to dump
+the CSV to. If you want output to your terminal, use ``-`` as the output filename.
+
+.. argparse::
+   :ref: ecl2df.ecl2csv.get_parser
+   :prog: ecl2csv

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,8 @@ data format.
 
    introduction
    usage
-   scripts
+   ecl2csv
+   csv2ecl
    modules
    installation
    contribution


### PR DESCRIPTION
Menu did not work when similar subcommands were mentioned
in the same document. Split to two files