### PR TITLE
Revert deprecation on datetime indices, support 500 year timespan

### DIFF
--- a/ecl2df/summary.py
+++ b/ecl2df/summary.py
@@ -221,7 +221,7 @@ def df(
     support for string mnenomics for the time index.
 
     The dataframe is always indexed by DATE, and the datatype for the
-    index will be usually be datetime64[ns] as long as all dates are
+    index will usually be datetime64[ns] as long as all dates are
     before year 2262. If a longer time range is detected, the index.dtype
     will be object, and consisting of datetime.datetime() objects. The index
     is always named "DATE".
@@ -425,7 +425,7 @@ def _fix_dframe_for_libecl(dframe: pd.DataFrame) -> pd.DataFrame:
                 index=dframe.index,
             )
 
-        dframe.set_index(dframe["DATE"], inplace=True)
+        dframe.set_index("DATE", inplace=True)
     if not isinstance(
         dframe.index.values[0], (dt.datetime, np.datetime64, pd.Timestamp)
     ):
@@ -450,7 +450,7 @@ def _fix_dframe_for_libecl(dframe: pd.DataFrame) -> pd.DataFrame:
             str({colname.partition(":")[0] + ":*" for colname in block_columns}),
         )
 
-    return dframe.drop("DATE", axis="columns", errors="ignore")
+    return dframe
 
 
 def df2eclsum(

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -88,11 +88,6 @@ def test_summary2df_dates(caplog):
     """Test that we have some API possibilities with ISO dates"""
     eclfiles = EclFiles(DATAFILE)
 
-    # Later, ecl2df.summary will always return a datetime index.
-    with pytest.warns(FutureWarning) as fut_warn:
-        summary.df(eclfiles, time_index="yearly")
-        assert "Use datetime=True as argument" in str(fut_warn[0].message)
-
     sumdf = summary.df(
         eclfiles,
         start_date=datetime.date(2002, 1, 2),
@@ -233,6 +228,105 @@ def test_datenormalization():
         eclfiles, column_keys="FOPT", time_index="yearly", datetime=True
     )
     assert str(yearly.index[-1])[0:10] == "2004-01-01"
+
+
+def test_extrapolation():
+    """Summary data should be possible to extrapolate into
+    the future, rates should be zero, cumulatives should be constant"""
+    eclfiles = EclFiles(DATAFILE)
+    lastfopt = summary.df(
+        eclfiles, column_keys="FOPT", time_index="last", datetime=True
+    )["FOPT"].values[0]
+    answer = pd.DataFrame(
+        # This is the maximal date for datetime64[ns]
+        index=[np.datetime64("2262-04-11")],
+        columns=["FOPT", "FOPR"],
+        data=[[lastfopt, 0.0]],
+    ).rename_axis("DATE")
+
+    pd.testing.assert_frame_equal(
+        summary.df(
+            eclfiles,
+            column_keys=["FOPT", "FOPR"],
+            time_index="2262-04-11",
+            datetime=True,
+        ),
+        answer,
+    )
+    pd.testing.assert_frame_equal(
+        summary.df(
+            eclfiles,
+            column_keys=["FOPT", "FOPR"],
+            time_index=[datetime.date(2262, 4, 11)],
+            # NB: df() does not support datetime64 for time_index
+            datetime=True,
+        ),
+        answer,
+    )
+
+    # Pandas does not support DatetimeIndex beyound 2262:
+    with pytest.raises(pd.errors.OutOfBoundsDatetime):
+        summary.df(
+            eclfiles,
+            column_keys=["FOPT"],
+            time_index=[datetime.date(2300, 1, 1)],
+            datetime=True,
+        )
+
+    # But without datetime, we can get it extrapolated by libecl:
+    assert summary.df(
+        eclfiles, column_keys=["FOPT"], time_index=[datetime.date(2300, 1, 1)]
+    )["FOPT"].values == [lastfopt]
+
+
+def test_foreseeable_future(tmpdir):
+    """The foreseeable future in reservoir simulation is "defined" as 500 years.
+
+    Check that we support summary files with this timespan"""
+    tmpdir.chdir()
+    src_dframe = pd.DataFrame(
+        [
+            {"DATE": "2000-01-01", "FPR": 200},
+            {"DATE": "2500-01-01", "FPR": 180},
+        ]
+    )
+    eclsum = df2eclsum(src_dframe, casename="PLUGABANDON")
+
+    dframe = summary.df(eclsum)
+    assert (
+        dframe.index
+        == [
+            datetime.datetime(2000, 1, 1),
+            # This discrepancy is due to seconds as a 32-bit float
+            # having an accuracy limit (roundoff-error)
+            # https://github.com/equinor/ecl/issues/803
+            datetime.datetime(2499, 12, 31, 23, 55, 44),
+        ]
+    ).all()
+
+    # Try with one-year timesteps:
+    src_dframe = pd.DataFrame(
+        {
+            "DATE": pd.date_range("2000-01-01", "2069-01-01", freq="YS"),
+            "FPR": range(70),
+        }
+    )
+    eclsum = df2eclsum(src_dframe, casename="PLUGABANDON")
+    dframe = summary.df(eclsum)
+    # Still buggy:
+    assert dframe.index[-1] == datetime.datetime(2068, 12, 31, 23, 57, 52)
+
+    # Try with one-year timesteps, starting late:
+    src_dframe = pd.DataFrame(
+        {
+            "DATE": [datetime.date(2400 + year, 1, 1) for year in range(69)],
+            "FPR": range(69),
+        }
+    )
+    eclsum = df2eclsum(src_dframe, casename="PLUGABANDON")
+    dframe = summary.df(eclsum)
+    # Works fine when stepping only 68 years:
+    assert dframe.index[-1] == datetime.datetime(2468, 1, 1, 0, 0, 0)
 
 
 def test_resample_smry_dates():
@@ -414,9 +508,39 @@ def test_smry_meta_synthetic():
         (pd.DataFrame(), pd.DataFrame()),
         # # # # # # # # # # # # # # # # # # # # # # # #
         (
-            pd.DataFrame([{"DATE": "2016-01-01", "FOPT": 1}]),
+            pd.DataFrame([{"DATE": "2516-01-01", "FOPT": 1}]),
             pd.DataFrame(
-                [{"FOPT": 1}], index=[pd.to_datetime("2016-01-01")]
+                [{"FOPT": 1}], index=[datetime.datetime(2516, 1, 1)]
+            ).rename_axis("DATE"),
+        ),
+        # # # # # # # # # # # # # # # # # # # # # # # #
+        (
+            pd.DataFrame([{"DATE": np.datetime64("2016-01-01"), "FOPT": 1}]),
+            pd.DataFrame(
+                [{"FOPT": 1}], index=[datetime.datetime(2016, 1, 1)]
+            ).rename_axis("DATE"),
+        ),
+        # # # # # # # # # # # # # # # # # # # # # # # #
+        (
+            pd.DataFrame(
+                [{"DATE": pd.Timestamp(datetime.date(2016, 1, 1)), "FOPT": 1}]
+            ),
+            pd.DataFrame(
+                [{"FOPT": 1}], index=[datetime.datetime(2016, 1, 1)]
+            ).rename_axis("DATE"),
+        ),
+        # # # # # # # # # # # # # # # # # # # # # # # #
+        (
+            pd.DataFrame(
+                [
+                    {
+                        "DATE": datetime.datetime(2016, 1, 1, 12, 34, 56),
+                        "FOPT": 1,
+                    }
+                ]
+            ),
+            pd.DataFrame(
+                [{"FOPT": 1}], index=[datetime.datetime(2016, 1, 1, 12, 34, 56)]
             ).rename_axis("DATE"),
         ),
         # # # # # # # # # # # # # # # # # # # # # # # #
@@ -428,9 +552,17 @@ def test_smry_meta_synthetic():
         ),
         # # # # # # # # # # # # # # # # # # # # # # # #
         (
-            pd.DataFrame([{"DATE": datetime.date(2016, 1, 1), "FOPT": 1}]),
+            pd.DataFrame([{"DATE": datetime.date(2017, 1, 1), "FOPT": 1}]),
             pd.DataFrame(
-                [{"FOPT": 1}], index=[pd.to_datetime("2016-01-01")]
+                [{"FOPT": 1}], index=[datetime.datetime(2017, 1, 1)]
+            ).rename_axis("DATE"),
+        ),
+        # # # # # # # # # # # # # # # # # # # # # # # #
+        (
+            # Dates that go beyond Pandas' datetime64[ns] limits:
+            pd.DataFrame([{"DATE": datetime.date(2517, 1, 1), "FOPT": 1}]),
+            pd.DataFrame(
+                [{"FOPT": 1}], index=[datetime.datetime(2517, 1, 1)]
             ).rename_axis("DATE"),
         ),
         # # # # # # # # # # # # # # # # # # # # # # # #
@@ -469,7 +601,7 @@ def test_smry_meta_synthetic():
 def test_fix_dframe_for_libecl(dframe, expected_dframe):
     """Test the dataframe preprocessor/validator for df2eclsum works"""
     pd.testing.assert_frame_equal(
-        _fix_dframe_for_libecl(dframe), expected_dframe, check_dtype=False
+        _fix_dframe_for_libecl(dframe), expected_dframe, check_index_type=False
     )
 
 
@@ -479,6 +611,7 @@ def test_fix_dframe_for_libecl(dframe, expected_dframe):
         (pd.DataFrame()),
         (pd.DataFrame([{"DATE": "2016-01-01", "FOPT": 1000}])),
         (pd.DataFrame([{"DATE": "2016-01-01", "FOPT": 1000, "FOPR": 100}])),
+        (pd.DataFrame([{"DATE": "3016-01-01", "FOPT": 1000}])),
         # # # # # # # # # # # # # # # # # # # # # # # #
         (
             pd.DataFrame(
@@ -611,7 +744,7 @@ def test_df2eclsum_errors():
         df2eclsum(dframe, casename="FOOBAR.UNSMRY")  # .UNSMRY should not be included
 
     # No date included:
-    with pytest.raises(ValueError, match="dataframe must have a DatetimeIndex"):
+    with pytest.raises(ValueError, match="dataframe must have a datetime index"):
         df2eclsum(pd.DataFrame([{"FOPT": 1000}]))
 
 


### PR DESCRIPTION
Uncovering current bugs both in libecl and Pandas, circumvented
in this patch.

Pandas datetime indices are datetime64[ns] only, and is limited to year 2262, which
is not acceptable for ecl2df.