### PR TITLE
Solve logging bug for summary

### DIFF
--- a/ecl2df/summary.py
+++ b/ecl2df/summary.py
@@ -568,7 +568,7 @@ def summary_main(args):
     )
     if sum_df.empty:
         logger.warning("Empty summary data being written to disk!")
-    write_dframe_stdout_file(sum_df, args.output, logger)
+    write_dframe_stdout_file(sum_df, args.output, index=True, caller_logger=logger)
 
 
 def summary_reverse_main(args):


### PR DESCRIPTION
Prior to this fix, calling `--verbose` did not print the message with which filename was written to. The index option was set correct by pure luck.