### PR TITLE
Fix csv2ecl ert hook

### DIFF
--- a/ecl2df/csv2ecl.py
+++ b/ecl2df/csv2ecl.py
@@ -24,7 +24,7 @@ EXAMPLES = (
     "CSV2ECL(<SUBCOMMAND>=equil, <CSVFILE>=equil.csv, "
     "<OUTPUT>=eclipse/include/equil.inc)``"
     "CSV2ECL(<SUBCOMMAND>=summary, <CSVFILE>=summary-monthly.csv, "
-    "<OUTPUT>=MONTHLYSUMMARY)``"
+    "<OUTPUT>=eclipse/model/MONTHLYSUMMARY)``"
 )
 
 

--- a/ecl2df/csv2ecl.py
+++ b/ecl2df/csv2ecl.py
@@ -15,13 +15,16 @@ from ecl2df import __version__
 # String constants in use for generating ERT forward model documentation:
 DESCRIPTION = """Convert CSV files into Eclipse include files. Uses the command
 line utility ``csv2ecl``. Run ``csv2ecl --help`` to see which subcommands are supported.
-No options other than the output file is possible when
-used directly as a forward model."""
+No options other than the output file is possible when used directly as a forward model.
+When writing synthetic summary files, the ECLBASE with no filename suffix is expected
+as the OUTPUT argument."""
 CATEGORY = "utility.eclipse"
 EXAMPLES = (
     "``FORWARD_MODEL "
     "CSV2ECL(<SUBCOMMAND>=equil, <CSVFILE>=equil.csv, "
     "<OUTPUT>=eclipse/include/equil.inc)``"
+    "CSV2ECL(<SUBCOMMAND>=summary, <CSVFILE>=summary-monthly.csv, "
+    "<OUTPUT>=MONTHLYSUMMARY)``"
 )
 
 

--- a/ecl2df/summary.py
+++ b/ecl2df/summary.py
@@ -1,4 +1,5 @@
 """Provide a two-way Pandas DataFrame interface to Eclipse summary data (UNSMRY)"""
+import os
 import logging
 from pathlib import Path
 
@@ -694,6 +695,14 @@ def summary_reverse_main(args):
     summary_df = pd.read_csv(args.csvfile)
     logger.info("Parsed %s", args.csvfile)
 
-    eclsum = df2eclsum(summary_df, args.output)
+    outputdir = Path(args.output).parent
+    eclbase = Path(args.output).name
+
+    # EclSum.fwrite can only write to current directory:
+    cwd = os.getcwd()
+    os.chdir(outputdir)
+    eclsum = df2eclsum(summary_df, eclbase)
     EclSum.fwrite(eclsum)
+    os.chdir(cwd)
+
     logger.info("Wrote to %s and %s", args.output + ".UNSMRY", args.output + ".SMSPEC")

--- a/ecl2df/summary.py
+++ b/ecl2df/summary.py
@@ -647,8 +647,15 @@ def fill_parser(parser):
 
 def fill_reverse_parser(parser):
     """Fill a parser for the operation:  dataframe -> eclsum files"""
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        help="Basename for Eclipse output files",
+        default="SYNTSMRY",
+    )
     parser.add_argument("csvfile", help="Name of CSV file with summary data.")
-    parser.add_argument("ECLBASE", help="Basename for Eclipse output files")
     parser.add_argument("-v", "--verbose", action="store_true", help="Be verbose")
     parser.add_argument("--debug", action="store_true", help="Be verbose")
     return parser
@@ -687,8 +694,6 @@ def summary_reverse_main(args):
     summary_df = pd.read_csv(args.csvfile)
     logger.info("Parsed %s", args.csvfile)
 
-    eclsum = df2eclsum(summary_df, args.ECLBASE)
+    eclsum = df2eclsum(summary_df, args.output)
     EclSum.fwrite(eclsum)
-    logger.info(
-        "Wrote to %s and %s", args.ECLBASE + ".UNSMRY", args.ECLBASE + ".SMSPEC"
-    )
+    logger.info("Wrote to %s and %s", args.output + ".UNSMRY", args.output + ".SMSPEC")

--- a/tests/test_ert_hooks.py
+++ b/tests/test_ert_hooks.py
@@ -84,6 +84,10 @@ def test_ecl2csv_through_ert(tmpdir):
             + "<SUBCOMMAND>={0}, <CSVFILE>={0}.csv, <OUTPUT>={0}.inc".format(subcommand)
             + ")"
         )
+    ert_config.append(
+        "FORWARD_MODEL CSV2ECL(<SUBCOMMAND>=summary, <CSVFILE>=summary-yearly.csv), "
+        "<OUTPUT>=SUMYEARLY)"
+    )
 
     ert_config_filename = "ecl2csv_test.ert"
     Path(ert_config_filename).write_text("\n".join(ert_config), encoding="utf-8")

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,5 +1,3 @@
-"""Test module for nnc2df"""
-
 import os
 import sys
 import datetime
@@ -765,6 +763,7 @@ def test_csv2ecl_summary(tmpdir):
         "summary",
         "-v",
         "summary.csv",
+        "--output",
         "SYNTHETIC",
     ]
     csv2ecl.main()

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -747,7 +747,7 @@ def test_df2eclsum_errors():
 
 
 @pytest.mark.integration
-def test_csv2ecl_summary(tmpdir):
+def test_csv2ecl_summary(tmpdir, mocker):
     """Check that we can call df2eclsum through the csv2ecl command line
     utility"""
     dframe = pd.DataFrame(
@@ -758,14 +758,34 @@ def test_csv2ecl_summary(tmpdir):
     )
     tmpdir.chdir()
     dframe.to_csv("summary.csv")
-    sys.argv = [
-        "csv2ecl",
-        "summary",
-        "-v",
-        "summary.csv",
-        "--output",
-        "SYNTHETIC",
-    ]
+    mocker.patch(
+        "sys.argv",
+        [
+            "csv2ecl",
+            "summary",
+            "-v",
+            "summary.csv",
+            "--output",
+            "SYNTHETIC",
+        ],
+    )
     csv2ecl.main()
     assert Path("SYNTHETIC.UNSMRY").is_file()
     assert Path("SYNTHETIC.SMSPEC").is_file()
+
+    # Check that we can write to a subdirectory
+    Path("foo").mkdir()
+    mocker.patch(
+        "sys.argv",
+        [
+            "csv2ecl",
+            "summary",
+            "-v",
+            "summary.csv",
+            "--output",
+            str(Path("foo") / Path("SYNTHETIC")),
+        ],
+    )
+    csv2ecl.main()
+    assert ("foo" / Path("SYNTHETIC.UNSMRY")).is_file()
+    assert ("foo" / Path("SYNTHETIC.SMSPEC")).is_file()


### PR DESCRIPTION
Two commits solving two bugs:

1: csv2ecl summary did not work as an ERT forward model due to the argparse argument not being aligned. This had to be changed. Few users assumed, so this can be changed with no deprecation period. csv2ecl summary is still new.

2. cvs2ecl summary could not write to subdirectories, which is the natural setting for an  ERT forward model. Added as a feature.