### PR TITLE
Read zonemap functionality moved to common module

### DIFF
--- a/ecl2df/common.py
+++ b/ecl2df/common.py
@@ -624,7 +624,7 @@ def stack_on_colnames(dframe, sep="@", stackcolname="DATE", inplace=True):
     return dframe
 
 
-def read_zonemap(filename):
+def parse_zonemapfile(filename: str):
     """Return a dictionary from (int) K layers in the simgrid to strings
 
     Typical usage is to map from grid layer to zone names.
@@ -645,9 +645,7 @@ def read_zonemap(filename):
         dict, integer keys which are the K layers. Every layer mentioned
             in the interval in the input file is present. Can be empty.
     """
-    assert isinstance(filename, str)
-    with open(filename, "r") as fin:
-        zonelines = fin.readlines()
+    zonelines = Path(filename).read_text().splitlines()
     zonelines = [line.strip() for line in zonelines]
     zonelines = [line.split("--")[0] for line in zonelines]
     zonelines = [line for line in zonelines if not line.startswith("#")]
@@ -665,5 +663,5 @@ def read_zonemap(filename):
         except ValueError:
             logger.error("Could not parse zonemapfile %s", filename)
             logger.error("Failed on content: %s", line)
-            return {}
+            return None
     return zonemap

--- a/ecl2df/common.py
+++ b/ecl2df/common.py
@@ -623,6 +623,7 @@ def stack_on_colnames(dframe, sep="@", stackcolname="DATE", inplace=True):
     dframe.index.name = ""
     return dframe
 
+
 def read_zonemap(filename):
     """Return a dictionary from (int) K layers in the simgrid to strings
 
@@ -664,5 +665,5 @@ def read_zonemap(filename):
         except ValueError:
             logger.error("Could not parse zonemapfile %s", filename)
             logger.error("Failed on content: %s", line)
-            return
+            return {}
     return zonemap

--- a/ecl2df/common.py
+++ b/ecl2df/common.py
@@ -627,23 +627,23 @@ def stack_on_colnames(dframe, sep="@", stackcolname="DATE", inplace=True):
 def read_zonemap(filename):
     """Return a dictionary from (int) K layers in the simgrid to strings
 
-        Typical usage is to map from grid layer to zone names.
+    Typical usage is to map from grid layer to zone names.
 
-        The layer filename must currently follow format::
+    The layer filename must currently follow format::
 
-          'ZoneA' 1-4
-          'ZoneB' 5-10
+      'ZoneA' 1-4
+      'ZoneB' 5-10
 
-        where the single quotes are optional for zones without spaces.
-        Write single layer zones as 11-11. NB: ResInsight requires single
-        quotes always.
+    where the single quotes are optional for zones without spaces.
+    Write single layer zones as 11-11. NB: ResInsight requires single
+    quotes always.
 
-        Args:
-            filename (str): Absolute path to a zone map file (lyr format)
+    Args:
+        filename (str): Absolute path to a zone map file (lyr format)
 
-        Returns:
-            dict, integer keys which are the K layers. Every layer mentioned
-                in the interval in the input file is present. Can be empty.
+    Returns:
+        dict, integer keys which are the K layers. Every layer mentioned
+            in the interval in the input file is present. Can be empty.
     """
     assert isinstance(filename, str)
     with open(filename, "r") as fin:

--- a/ecl2df/common.py
+++ b/ecl2df/common.py
@@ -638,16 +638,15 @@ def read_zonemap(filename):
         quotes always.
 
         Args:
-            filename (str): Absolute path to a zone map file
+            filename (str): Absolute path to a zone map file (lyr format)
 
         Returns:
             dict, integer keys which are the K layers. Every layer mentioned
                 in the interval in the input file is present. Can be empty.
     """
-    assert isinstance(filename, str), "'filename' must be a string."
-    if not Path(filename).is_file():
-        return {}
-    zonelines = open(filename).readlines()
+    assert isinstance(filename, str)
+    with open(filename, "r") as fin:
+        zonelines = fin.readlines()
     zonelines = [line.strip() for line in zonelines]
     zonelines = [line.split("--")[0] for line in zonelines]
     zonelines = [line for line in zonelines if not line.startswith("#")]

--- a/ecl2df/common.py
+++ b/ecl2df/common.py
@@ -8,6 +8,7 @@ import logging
 import datetime
 import itertools
 from pathlib import Path
+import shlex
 
 import numpy as np
 import pandas as pd
@@ -621,3 +622,48 @@ def stack_on_colnames(dframe, sep="@", stackcolname="DATE", inplace=True):
     del dframe["level_0"]
     dframe.index.name = ""
     return dframe
+
+def read_zonemap(filename):
+    """Return a dictionary from (int) K layers in the simgrid to strings
+
+        Typical usage is to map from grid layer to zone names.
+
+        The layer filename must currently follow format::
+
+          'ZoneA' 1-4
+          'ZoneB' 5-10
+
+        where the single quotes are optional for zones without spaces.
+        Write single layer zones as 11-11. NB: ResInsight requires single
+        quotes always.
+
+        Args:
+            filename (str): Absolute path to a zone map file
+
+        Returns:
+            dict, integer keys which are the K layers. Every layer mentioned
+                in the interval in the input file is present. Can be empty.
+    """
+    assert isinstance(filename, str), "'filename' must be a string."
+    if not Path(filename).is_file():
+        return {}
+    zonelines = open(filename).readlines()
+    zonelines = [line.strip() for line in zonelines]
+    zonelines = [line.split("--")[0] for line in zonelines]
+    zonelines = [line for line in zonelines if not line.startswith("#")]
+    zonelines = filter(len, zonelines)
+
+    zonemap = {}
+    for line in zonelines:
+        try:
+            linesplit = shlex.split(line)
+            map(str.strip, linesplit)
+            filter(len, linesplit)
+            (k_0, k_1) = "".join(linesplit[1:]).split("-")
+            for k_idx in range(int(k_0), int(k_1) + 1):
+                zonemap[k_idx] = linesplit[0]
+        except ValueError:
+            logger.error("Could not parse zonemapfile %s", filename)
+            logger.error("Failed on content: %s", line)
+            return
+    return zonemap

--- a/ecl2df/eclfiles.py
+++ b/ecl2df/eclfiles.py
@@ -199,7 +199,18 @@ class EclFiles(object):
         return self._eclbase + ".PRT"
 
     def get_zonemap(self, filename=None):
-        """Return a dictionary with a layer to zone map
+        """Return a dictionary from (int) K layers in the simgrid to strings
+
+        Typical usage is to map from grid layer to zone names.
+
+        The layer filename must currently follow format::
+
+          'ZoneA' 1-4
+          'ZoneB' 5-10
+
+        where the single quotes are optional for zones without spaces.
+        Write single layer zones as 11-11. NB: ResInsight requires single
+        quotes always.
 
         Args:
             filename (str): Name of file. If relative path, relative to DATA

--- a/ecl2df/eclfiles.py
+++ b/ecl2df/eclfiles.py
@@ -3,7 +3,6 @@
 import os
 import errno
 import logging
-import shlex
 from pathlib import Path
 
 try:

--- a/ecl2df/eclfiles.py
+++ b/ecl2df/eclfiles.py
@@ -237,7 +237,7 @@ class EclFiles(object):
             logger.warning("Zonefile %s not found, ignoring", fullpath)
             return {}
 
-        return common.read_zonemap(fullpath)
+        return common.parse_zonemapfile(fullpath)
 
 
 def rreplace(pat, sub, string):

--- a/ecl2df/eclfiles.py
+++ b/ecl2df/eclfiles.py
@@ -16,6 +16,7 @@ except ImportError:
 from ecl.eclfile import EclFile
 from ecl.grid import EclGrid
 from ecl.summary import EclSum
+from ecl2df import common
 
 logger = logging.getLogger(__name__)
 
@@ -198,18 +199,7 @@ class EclFiles(object):
         return self._eclbase + ".PRT"
 
     def get_zonemap(self, filename=None):
-        """Return a dictionary from (int) K layers in the simgrid to strings
-
-        Typical usage is to map from grid layer to zone names.
-
-        The layer filename must currently follow format::
-
-          'ZoneA' 1-4
-          'ZoneB' 5-10
-
-        where the single quotes are optional for zones without spaces.
-        Write single layer zones as 11-11. NB: ResInsight requires single
-        quotes always.
+        """Return a dictionary with a layer to zone map
 
         Args:
             filename (str): Name of file. If relative path, relative to DATA
@@ -237,26 +227,7 @@ class EclFiles(object):
             logger.warning("Zonefile %s not found, ignoring", fullpath)
             return {}
 
-        zonelines = open(fullpath).readlines()
-        zonelines = [line.strip() for line in zonelines]
-        zonelines = [line.split("--")[0] for line in zonelines]
-        zonelines = [line for line in zonelines if not line.startswith("#")]
-        zonelines = filter(len, zonelines)
-
-        zonemap = {}
-        for line in zonelines:
-            try:
-                linesplit = shlex.split(line)
-                map(str.strip, linesplit)
-                filter(len, linesplit)
-                (k_0, k_1) = "".join(linesplit[1:]).split("-")
-                for k_idx in range(int(k_0), int(k_1) + 1):
-                    zonemap[k_idx] = linesplit[0]
-            except ValueError:
-                logger.error("Could not parse zonemapfile %s", filename)
-                logger.error("Failed on content: %s", line)
-                return
-        return zonemap
+        return common.read_zonemap(fullpath)
 
 
 def rreplace(pat, sub, string):


### PR DESCRIPTION
I have moved the parsing of lyr files to a general function in the common module. This makes it easiser to use from outside ecl2df. Functionality in the EclFiles class is exactly as before.