### PR TITLE
Solve numpy 1.20 deprecation warning

### DIFF
--- a/tests/test_rft.py
+++ b/tests/test_rft.py
@@ -6,7 +6,6 @@ import datetime
 from pathlib import Path
 
 import pandas as pd
-import numpy as np
 
 import pytest
 
@@ -27,8 +26,8 @@ def test_rftrecords2df():
         rftrecs["timeindex"].unique()
     )
     assert set(rftrecs["recordtype"].unique()) == set(["REAL", "INTE", "CHAR"])
-    assert rftrecs["timeindex"].dtype == np.int
-    assert rftrecs["recordidx"].dtype == np.int
+    assert rftrecs["timeindex"].dtype == int
+    assert rftrecs["recordidx"].dtype == int
 
     # Test that we have a consecutive index in "recordidx"
     assert (rftrecs["recordidx"] == rftrecs.index).all()


### PR DESCRIPTION
Before this PR, this warning was emitted:

```
tests/test_rft.py::test_rftrecords2df
  /home/berland/projects/ecl2df/tests/test_rft.py:30: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    assert rftrecs["timeindex"].dtype == np.int

```