### PR TITLE
Integrate sphinx-apidoc command into conf.py

### DIFF
--- a/.github/workflows/ecl2df.yml
+++ b/.github/workflows/ecl2df.yml
@@ -73,7 +73,6 @@ jobs:
 
       - name: Build documentation
         run: |
-          sphinx-apidoc -f -H "API for ecl2df" -o docs ecl2df
           python setup.py build_sphinx
 
       - name: Update GitHub pages

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,17 +14,17 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-
 import pkg_resources
+import datetime
 
 # -- Project information -----------------------------------------------------
 
 project = "ecl2df"
-author = u"Håvard Berland"
-copyright = "Equinor 2019-2020"
+author = "Håvard Berland"
+copyright = f"Equinor 2019-{datetime.datetime.now().year}"
 
 # The short X.Y version
-import ecl2df
+import ecl2df  # noqa
 
 release = pkg_resources.get_distribution("ecl2df").version
 version = release
@@ -39,7 +39,9 @@ version = release
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "autoapi.sphinx",
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
     "sphinx.ext.githubpages",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
@@ -47,6 +49,12 @@ extensions = [
     "sphinx_autodoc_typehints",
     "sphinxarg.ext",
 ]
+
+autoapi_modules: dict = {"ecl2df": None}
+
+autodoc_default_options = {"members": None}
+
+autosummary_generate = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -70,7 +78,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
+exclude_patterns: list = []
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None
@@ -115,7 +123,7 @@ htmlhelp_basename = "ecl2dfdoc"
 
 # -- Options for LaTeX output ------------------------------------------------
 
-latex_elements = {
+latex_elements: dict = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,10 +13,16 @@ data format.
    usage
    ecl2csv
    csv2ecl
-   modules
    installation
    contribution
    history
+
+.. toctree::
+   :hidden:
+   :maxdepth: 10
+   :caption: Python API
+
+   ecl2df/ecl2df
 
 Indices and tables
 ==================

--- a/ecl2df/__init__.py
+++ b/ecl2df/__init__.py
@@ -1,4 +1,3 @@
-"""ecl2df"""
 import importlib
 from typing import List
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ REQUIREMENTS = [
 TEST_REQUIREMENTS = Path("test_requirements.txt").read_text().splitlines()
 
 DOCS_REQUIREMENTS = [
+    "autoapi",
     "ipython",
     "rstcheck",
     "sphinx",


### PR DESCRIPTION
Left margin menu in generated docs are slightly altered,
the API docs are now at the end, and stands more clearly
out.