### PR TITLE
Fix unclosed resource/file warning

### DIFF
--- a/ecl2df/common.py
+++ b/ecl2df/common.py
@@ -84,9 +84,7 @@ MAGIC_STDOUT: str = "-"
 SVG_COLOR_NAMES = [
     color.lower()
     for color in (
-        open(Path(__file__).parent / "svg_color_keyword_names.txt", "r")
-        .read()
-        .splitlines()
+        (Path(__file__).parent / "svg_color_keyword_names.txt").read_text().splitlines()
     )
 ]
 


### PR DESCRIPTION
Removes
```
 [...]/python3.6/site-packages/ecl2df/common.py:87: ResourceWarning:

unclosed file <_io.TextIOWrapper name='[...]/python3.6/site-packages/ecl2df/svg_color_keyword_names.txt' mode='r' encoding='UTF-8'>
```