### PR TITLE
Explicitly drop a non-numeric column

### DIFF
--- a/ecl2df/pillars.py
+++ b/ecl2df/pillars.py
@@ -434,7 +434,7 @@ def pillars_main(args) -> None:
     if groupbies:
         dframe = dframe.groupby(groupbies).agg(aggregators).reset_index()
     elif args.group:
-        dframe = dframe.mean().to_frame().transpose()
+        dframe = dframe.drop("PILLAR", axis=1).mean().to_frame().transpose()
     dframe["PORO"] = dframe["PORV"] / dframe["VOLUME"]
     common.write_dframe_stdout_file(
         dframe, args.output, index=False, caller_logger=logger


### PR DESCRIPTION
Solves a Pandas 1.3.0 FutureWarning, and avoids a future TypeError