### PR TITLE
Remove non-reachable GRUPTREE code and add tests

### DIFF
--- a/ecl2df/gruptree.py
+++ b/ecl2df/gruptree.py
@@ -123,16 +123,10 @@ def df(
                     steplist = parse_opmio_tstep_rec(rec)
                     # Assuming not LAB units, then the unit is days.
                     days = sum(steplist)
-                    if days <= 0:
-                        logger.critical("Invalid TSTEP, summed to %s days", str(days))
-                        return pd.DataFrame()
                     date += datetime.timedelta(days=days)
                     logger.info(
                         "Advancing %s days to %s through TSTEP", str(days), str(date)
                     )
-            else:
-                logger.critical("BUG: Should not get here")
-                return pd.DataFrame()
         if kword.name in ["GRUPTREE", "BRANPROP"]:
             found_keywords[kword.name] = True
             renamer = (


### PR DESCRIPTION
Leave those bugs to actually appear, and then determine what is the
correct way to handle it, probably some exception will occur which
is more correct than returning an empty dataframe and doing logging.