### PR TITLE
Handling of defaulted coordinates in WELOPEN (item 3-5)

### DIFF
--- a/ecl2df/compdat.py
+++ b/ecl2df/compdat.py
@@ -328,11 +328,12 @@ def expand_welopen_defaults(
             # If no coordinates are defaulted, there is nothing to expand.
             exp_welopen.append(row)
         else:
-            # If some of the coordinates is defaulted then we filter the
+            # If some of the coordinates are defaulted then we filter the
             # compdat dataframe to find the matching connections and expand
             # the WELOPEN row with those
             compdat_filtered = compdat_df[compdat_df["WELL"] == row["WELL"]]
             for coord in ["I", "J", "K"]:
+                # In COMPDAT the K coordinate is named K1/K2.
                 compdat_coord = coord + "1" if coord == "K" else coord
                 if not is_default(row[coord]):
                     compdat_filtered = compdat_filtered[
@@ -345,7 +346,7 @@ def expand_welopen_defaults(
                 raise ValueError(
                     "No connections are matching WELOPEN keyword with defaulted "
                     "coordinates:"
-                    f"\n {str(row)} "
+                    f"\n {row} "
                 )
 
             for _, compdat_row in compdat_filtered.iterrows():
@@ -886,13 +887,13 @@ def applywelopen(
         else:
             raise ValueError(
                 "A WELOPEN keyword contains data that could not be parsed. "
-                f"\n {str(row)} "
+                f"\n {row} "
             )
 
         if previous_state.empty:
             raise ValueError(
                 "A WELOPEN keyword is not acting on any existing connection. "
-                f"\n {str(row)} "
+                f"\n {row} "
             )
 
         new_state = previous_state

--- a/ecl2df/compdat.py
+++ b/ecl2df/compdat.py
@@ -331,9 +331,22 @@ def expand_welopen_defaults(
             # If some of the coordinates are defaulted then we filter the
             # compdat dataframe to find the matching connections and expand
             # the WELOPEN row with those
-            compdat_filtered = compdat_df[compdat_df["DATE"] <= row["DATE"]]
+
+            # Any compdat entry with DATE==None are kept as they
+            # are assumed to have an earlier date than any dates defined
+            compdat_filtered = compdat_df[compdat_df["DATE"].isnull()]
+
+            # If the welopen entry DATE!=None we filter on compdat entries
+            # <= this date
+            if row["DATE"] is not None:
+                compdat_filtered = pd.concat(
+                    [compdat_filtered, compdat_df[compdat_df["DATE"] <= row["DATE"]]]
+                )
+
+            # Filter on well name
             compdat_filtered = compdat_filtered[compdat_filtered["WELL"] == row["WELL"]]
 
+            # Filter on coordinates
             for coord in ["I", "J", "K"]:
                 # In COMPDAT the K coordinate is named K1/K2.
                 compdat_coord = coord + "1" if coord == "K" else coord

--- a/ecl2df/compdat.py
+++ b/ecl2df/compdat.py
@@ -331,7 +331,9 @@ def expand_welopen_defaults(
             # If some of the coordinates are defaulted then we filter the
             # compdat dataframe to find the matching connections and expand
             # the WELOPEN row with those
-            compdat_filtered = compdat_df[compdat_df["WELL"] == row["WELL"]]
+            compdat_filtered = compdat_df[compdat_df["DATE"] <= row["DATE"]]
+            compdat_filtered = compdat_filtered[compdat_filtered["WELL"] == row["WELL"]]
+
             for coord in ["I", "J", "K"]:
                 # In COMPDAT the K coordinate is named K1/K2.
                 compdat_coord = coord + "1" if coord == "K" else coord

--- a/ecl2df/compdat.py
+++ b/ecl2df/compdat.py
@@ -313,9 +313,10 @@ def expand_welopen_defaults(
 
     exp_welopen = []
     for _, row in welopen_df.iterrows():
-        print(row)
+        # print(row)
 
-        if all([is_default(row[coord]) for coord in ["I", "J", "K"]]):
+        coord_defaulted = [is_default(row[coord]) for coord in ["I", "J", "K"]]
+        if all(coord_defaulted) or not any(coord_defaulted):
             exp_welopen.append(row)
         else:
             compdat_filtered = compdat_df[compdat_df["WELL"] == row["WELL"]]
@@ -326,12 +327,18 @@ def expand_welopen_defaults(
             if not is_default(row["K"]):
                 compdat_filtered = compdat_filtered[compdat_filtered["K1"] == row["K"]]
 
-            for _, compdat_row in compdat_filtered.iterrows():
-                exp_row = row.copy()
-                exp_row["I"] = compdat_row["I"]
-                exp_row["J"] = compdat_row["J"]
-                exp_row["K"] = compdat_row["K1"]
-                exp_welopen.append(exp_row)
+            # If compdat_filtered is empty it means that no connection is matching
+            # the criterias in WELOPEN, this will fail in applywelopen so we are
+            # letting it pass here
+            if compdat_filtered.empty:
+                exp_welopen.append(row)
+            else:
+                for _, compdat_row in compdat_filtered.iterrows():
+                    exp_row = row.copy()
+                    exp_row["I"] = compdat_row["I"]
+                    exp_row["J"] = compdat_row["J"]
+                    exp_row["K"] = compdat_row["K1"]
+                    exp_welopen.append(exp_row)
 
     return pd.DataFrame(exp_welopen)
 

--- a/tests/test_welopen.py
+++ b/tests/test_welopen.py
@@ -286,6 +286,44 @@ WELOPEN_CASES = [
         ),
         id="both-wildcard-wellname-and-defaulted-coordinates",
     ),
+    # Compdat changing with time. The WELOPEN statement is only acting on
+    # connections that have been defined at that date. In this test, the
+    # connections with I==1 and I==2 will be SHUT, but not I==3
+    pytest.param(
+        """
+    DATES
+     1 JAN 2000 /
+    /
+    COMPDAT
+     'OP1'  1 1 1 1 'OPEN' /
+    /
+    DATES
+     1 FEB 2000 /
+    /
+    COMPDAT
+     'OP1'  2 1 1 1 'OPEN' /
+    /
+    WELOPEN
+     'OP1'  'SHUT' 0 1 1 /
+    /
+    DATES
+     1 MAR 2000 /
+    /
+    COMPDAT
+     'OP1'  3 1 1 1 'OPEN' /
+    /
+    """,
+        pd.DataFrame(
+            columns=["DATE", "WELL", "I", "J", "K1", "K2", "OP/SH"],
+            data=[
+                [datetime.date(2000, 1, 1), "OP1", 1, 1, 1, 1, "OPEN"],
+                [datetime.date(2000, 2, 1), "OP1", 1, 1, 1, 1, "SHUT"],
+                [datetime.date(2000, 2, 1), "OP1", 2, 1, 1, 1, "SHUT"],
+                [datetime.date(2000, 3, 1), "OP1", 3, 1, 1, 1, "OPEN"],
+            ],
+        ),
+        id="welopen-defaults-compdat-changing-with-time",
+    ),
     pytest.param(
         """
     DATES
@@ -333,7 +371,7 @@ WELOPEN_CASES = [
         id="defaulted-complump-in-welopen-not-supported",
         marks=pytest.mark.xfail(
             raises=ValueError,
-            match="Defaulted COMPLUMPs in WELOPEN not supported",
+            match="Zeros for C1/C2 is not implemented",
         ),
     ),
     # STOP on connection is the same as SHUT

--- a/tests/test_welopen.py
+++ b/tests/test_welopen.py
@@ -221,9 +221,9 @@ WELOPEN_CASES = [
         pd.DataFrame(
             columns=["DATE", "WELL", "I", "J", "K1", "K2", "OP/SH"],
             data=[
+                [datetime.date(2000, 1, 1), "OP1", 1, 1, 2, 2, "OPEN"],
                 [datetime.date(2000, 1, 1), "OP1", 1, 1, 1, 1, "SHUT"],
                 [datetime.date(2000, 1, 1), "OP1", 2, 1, 1, 1, "SHUT"],
-                [datetime.date(2000, 1, 1), "OP1", 1, 1, 2, 2, "OPEN"],
             ],
         ),
         id="welopen-with-defaulted-I-coordinate",
@@ -251,12 +251,12 @@ WELOPEN_CASES = [
         pd.DataFrame(
             columns=["DATE", "WELL", "I", "J", "K1", "K2", "OP/SH"],
             data=[
-                [datetime.date(2000, 1, 1), "OP1", 1, 1, 1, 1, "SHUT"],
-                [datetime.date(2000, 1, 1), "OP1", 1, 1, 2, 2, "OPEN"],
-                [datetime.date(2000, 1, 1), "OP2", 1, 1, 1, 1, "SHUT"],
                 [datetime.date(2000, 1, 1), "OP2", 2, 2, 2, 2, "OPEN"],
-                [datetime.date(2000, 1, 1), "OP3", 1, 1, 1, 1, "SHUT"],
                 [datetime.date(2000, 1, 1), "OP3", 2, 1, 1, 1, "OPEN"],
+                [datetime.date(2000, 1, 1), "OP1", 1, 1, 2, 2, "OPEN"],
+                [datetime.date(2000, 1, 1), "OP1", 1, 1, 1, 1, "SHUT"],
+                [datetime.date(2000, 1, 1), "OP2", 1, 1, 1, 1, "SHUT"],
+                [datetime.date(2000, 1, 1), "OP3", 1, 1, 1, 1, "SHUT"],
             ],
         ),
         id="welopen-combinations-of-defaulted-coordinates",
@@ -279,9 +279,9 @@ WELOPEN_CASES = [
         pd.DataFrame(
             columns=["DATE", "WELL", "I", "J", "K1", "K2", "OP/SH"],
             data=[
+                [datetime.date(2000, 1, 1), "PROD", 1, 1, 1, 1, "OPEN"],
                 [datetime.date(2000, 1, 1), "OP1", 1, 1, 1, 1, "SHUT"],
                 [datetime.date(2000, 1, 1), "OP2", 1, 1, 2, 2, "SHUT"],
-                [datetime.date(2000, 1, 1), "PROD", 1, 1, 1, 1, "OPEN"],
             ],
         ),
         id="both-wildcard-wellname-and-defaulted-coordinates",
@@ -345,6 +345,46 @@ WELOPEN_CASES = [
             ],
         ),
         id="welopen-defaults-start",
+    ),
+    # No dates at all
+    pytest.param(
+        """
+    COMPDAT
+     'OP1'  1 1 1 1 'OPEN' /
+    /
+    WELOPEN
+     'OP1'  'SHUT' 0 1 1 /
+    /
+    """,
+        pd.DataFrame(
+            columns=["DATE", "WELL", "I", "J", "K1", "K2", "OP/SH"],
+            data=[
+                [None, "OP1", 1, 1, 1, 1, "SHUT"],
+            ],
+        ),
+        id="welopen-defaults-no-dates",
+    ),
+    # No start date, then a date later
+    pytest.param(
+        """
+    COMPDAT
+     'OP1'  1 1 1 1 'OPEN' /
+    /
+    DATES
+     1 JAN 2000 /
+    /
+    WELOPEN
+     'OP1'  'SHUT' 0 1 1 /
+    /
+    """,
+        pd.DataFrame(
+            columns=["DATE", "WELL", "I", "J", "K1", "K2", "OP/SH"],
+            data=[
+                [None, "OP1", 1, 1, 1, 1, "OPEN"],
+                [datetime.date(2000, 1, 1), "OP1", 1, 1, 1, 1, "SHUT"],
+            ],
+        ),
+        id="welopen-defaults-no-start-date",
     ),
     pytest.param(
         """
@@ -490,8 +530,8 @@ WELOPEN_CASES = [
             columns=["DATE", "WELL", "I", "J", "K1", "K2", "OP/SH"],
             data=[
                 [datetime.date(2000, 1, 1), "OP1", 1, 1, 1, 1, "OPEN"],
-                [datetime.date(2000, 1, 1), "OP1", 1, 1, 2, 2, "SHUT"],
                 [datetime.date(2000, 1, 1), "OP1", 1, 1, 3, 3, "OPEN"],
+                [datetime.date(2000, 1, 1), "OP1", 1, 1, 2, 2, "SHUT"],
             ],
         ),
         id="j-slicing",
@@ -843,9 +883,9 @@ WELOPEN_CASES = [
         pd.DataFrame(
             columns=["DATE", "WELL", "I", "J", "K1", "K2", "OP/SH"],
             data=[
+                [datetime.date(2000, 1, 1), "WI1", 3, 3, 3, 3, "OPEN"],
                 [datetime.date(2000, 1, 1), "B_1H", 1, 1, 1, 1, "SHUT"],
                 [datetime.date(2000, 1, 1), "B_2H", 2, 2, 2, 2, "SHUT"],
-                [datetime.date(2000, 1, 1), "WI1", 3, 3, 3, 3, "OPEN"],
             ],
         ),
         id="multiple-wells-via-wildcard",
@@ -875,9 +915,9 @@ WELOPEN_CASES = [
         pd.DataFrame(
             columns=["DATE", "WELL", "I", "J", "K1", "K2", "OP/SH"],
             data=[
+                [datetime.date(2000, 1, 1), "WI1", 3, 3, 3, 3, "OPEN"],
                 [datetime.date(2000, 1, 1), "OP1", 1, 1, 1, 1, "SHUT"],
                 [datetime.date(2000, 1, 1), "OP2", 2, 2, 2, 2, "SHUT"],
-                [datetime.date(2000, 1, 1), "WI1", 3, 3, 3, 3, "OPEN"],
                 [datetime.date(2000, 2, 1), "OP3", 4, 4, 4, 4, "OPEN"],
             ],
         ),
@@ -893,14 +933,7 @@ def test_welopen(test_input, expected):
     compdf = compdat.deck2dfs(deck)["COMPDAT"]
     columns_to_check = ["WELL", "I", "J", "K1", "K2", "OP/SH", "DATE"]
 
-    assert (
-        compdf[columns_to_check]
-        .sort_values(by=columns_to_check, axis=0)
-        .reset_index()[columns_to_check]
-        == expected[columns_to_check]
-        .sort_values(by=columns_to_check, axis=0)
-        .reset_index()[columns_to_check]
-    ).all(axis=None)
+    pd.testing.assert_frame_equal(compdf[columns_to_check], expected[columns_to_check])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_welopen.py
+++ b/tests/test_welopen.py
@@ -814,20 +814,6 @@ def test_welopen(test_input, expected):
     compdf = compdat.deck2dfs(deck)["COMPDAT"]
     columns_to_check = ["WELL", "I", "J", "K1", "K2", "OP/SH", "DATE"]
 
-    print(test_input)
-    print("calc")
-    print(
-        compdf[columns_to_check]
-        .sort_values(by=columns_to_check, axis=0)
-        .reset_index()[columns_to_check]
-    )
-    print("expected")
-    print(
-        expected[columns_to_check]
-        .sort_values(by=columns_to_check, axis=0)
-        .reset_index()[columns_to_check]
-    )
-
     assert (
         compdf[columns_to_check]
         .sort_values(by=columns_to_check, axis=0)

--- a/tests/test_welopen.py
+++ b/tests/test_welopen.py
@@ -286,6 +286,25 @@ WELOPEN_CASES = [
         ),
         id="both-wildcard-wellname-and-defaulted-coordinates",
     ),
+    pytest.param(
+        """
+    DATES
+     1 JAN 2000 /
+    /
+    COMPDAT
+     'OP1'  1 1 1 2 'OPEN' /
+    /
+    WELOPEN
+     'OP1'  'SHUT' 0 0 3 /
+    /
+    """,
+        None,
+        id="no-connections-matching-welopen-defaults",
+        marks=pytest.mark.xfail(
+            raises=ValueError,
+            match="No connections are matching WELOPEN keyword",
+        ),
+    ),
     # Defaulted COMPLUMPs in WELOPEN not supported
     pytest.param(
         """

--- a/tests/test_welopen.py
+++ b/tests/test_welopen.py
@@ -324,6 +324,28 @@ WELOPEN_CASES = [
         ),
         id="welopen-defaults-compdat-changing-with-time",
     ),
+    # Welopen defaults with START instead of DATES in the first timestep
+    pytest.param(
+        """
+    START
+     1 JAN 2000 /
+    /
+    COMPDAT
+     'OP1'  1 1 1 1 'OPEN' /
+    /
+    WELOPEN
+     'OP1'  'SHUT' 0 1 1 /
+    /
+
+    """,
+        pd.DataFrame(
+            columns=["DATE", "WELL", "I", "J", "K1", "K2", "OP/SH"],
+            data=[
+                [datetime.date(2000, 1, 1), "OP1", 1, 1, 1, 1, "SHUT"],
+            ],
+        ),
+        id="welopen-defaults-start",
+    ),
     pytest.param(
         """
     DATES

--- a/tests/test_welopen.py
+++ b/tests/test_welopen.py
@@ -120,6 +120,8 @@ WELOPEN_CASES = [
         ),
         id="welopen-stop-on-well",
     ),
+    # Both 1*, 0 and -1 are default values and give the same result:
+    # When all coordinates are defaulted, the connections are left OPEN
     pytest.param(
         """
     DATES
@@ -127,15 +129,21 @@ WELOPEN_CASES = [
     /
     COMPDAT
      'OP1' 1 1 1 1 'OPEN' /
+     'OP2' 1 1 1 1 'OPEN' /
+     'OP3' 1 1 1 1 'OPEN' /
     /
     WELOPEN
      'OP1' 'STOP' 1* 1* 1* /
+     'OP2' 'STOP' 0  0  0  /
+     'OP3' 'STOP' -1 -1 -1 /
     /
     """,
         pd.DataFrame(
             columns=["DATE", "WELL", "I", "J", "K1", "K2", "OP/SH"],
             data=[
                 [datetime.date(2000, 1, 1), "OP1", 1, 1, 1, 1, "OPEN"],
+                [datetime.date(2000, 1, 1), "OP2", 1, 1, 1, 1, "OPEN"],
+                [datetime.date(2000, 1, 1), "OP3", 1, 1, 1, 1, "OPEN"],
             ],
         ),
         id="welopen-stop-on-well-explicit-defaults",
@@ -173,6 +181,7 @@ WELOPEN_CASES = [
         ),
         id="welopen-shut-then-stop-on-well",
     ),
+    # Closes a connection with specified I, J, K
     pytest.param(
         """
     DATES
@@ -243,9 +252,7 @@ WELOPEN_CASES = [
             ],
         ),
     ),
-    # Both wilcard wells, all coordinates defaulted
-    # And no coordinates defined, which closes the well
-    # and not the connections
+    # Both wilcard well names and K coordinate defaulted with -1
     (
         """
     DATES
@@ -253,24 +260,24 @@ WELOPEN_CASES = [
     /
     COMPDAT
      'OP1'  1 1 1 1 'OPEN' /
-     'OP2'  1 1 1 1 'OPEN' /
+     'OP2'  1 1 2 2 'OPEN' /
      'PROD' 1 1 1 1 'OPEN' /
     /
     WELOPEN
-     'OP*'  'SHUT' 3* /
-     'PROD' 'SHUT'    /
+     'OP*'  'SHUT' 1 1 -1 /
     /
     """,
         pd.DataFrame(
             columns=["DATE", "WELL", "I", "J", "K1", "K2", "OP/SH"],
             data=[
                 [datetime.date(2000, 1, 1), "OP1", 1, 1, 1, 1, "SHUT"],
-                [datetime.date(2000, 1, 1), "OP2", 1, 1, 1, 1, "SHUT"],
+                [datetime.date(2000, 1, 1), "OP2", 1, 1, 2, 2, "SHUT"],
                 [datetime.date(2000, 1, 1), "PROD", 1, 1, 1, 1, "OPEN"],
             ],
         ),
     ),
-    # Fail with ValueError when both I,J,K (3-5) and completions number (6-7)
+    # STOP on connection is the same as SHUT
+    # (not that STOP on well gives OPEN connections)
     pytest.param(
         """
     DATES
@@ -291,6 +298,7 @@ WELOPEN_CASES = [
         ),
         id="welopen-stop-on-connection-is-shut",
     ),
+    # POPN is the same as OPEN
     pytest.param(
         """
     DATES
@@ -311,6 +319,7 @@ WELOPEN_CASES = [
         ),
         id="welopen-popn-on-connection-is-open",
     ),
+    # WELOPEN refers to a lumped connection, but COMPLUMP is missing
     pytest.param(
         """
     DATES
@@ -320,7 +329,6 @@ WELOPEN_CASES = [
      'OP1' 1 1 1 1 'OPEN' /
     /
     WELOPEN
-     -- This points to a lumped connection, but COMPLUMP is missing
      'OP1' 'SHUT' 1 1 1 1 1 /
     /
     """,
@@ -328,6 +336,7 @@ WELOPEN_CASES = [
         id="complump_missing",
         marks=pytest.mark.xfail(raises=ValueError),
     ),
+    # Well is missing
     pytest.param(
         """
     DATES


### PR DESCRIPTION
Fixes #334.

This PR implements the handling of default coordinates, item 3-5, in WELOPEN. The compdat dataframe is filtered to find all connections (in the well) that is matching the coordinates that are not defaulted.

