### PR TITLE
New module `wellcompletiondata`

### DIFF
--- a/ecl2df/__init__.py
+++ b/ecl2df/__init__.py
@@ -27,6 +27,7 @@ SUBMODULES: List[str] = [
     "satfunc",
     "summary",
     "trans",
+    "wellcompletiondata",
     "wellconnstatus",
     "wcon",
 ]

--- a/ecl2df/compdat.py
+++ b/ecl2df/compdat.py
@@ -978,7 +978,11 @@ def compdat_main(args):
     write_dframe_stdout_file(compdat_df, args.output, index=False, caller_logger=logger)
 
 
-def df(eclfiles: EclFiles, initvectors: Optional[List[str]] = None) -> pd.DataFrame:
+def df(
+    eclfiles: EclFiles,
+    initvectors: Optional[List[str]] = None,
+    zonemap_filename: Optional[str] = None,
+) -> pd.DataFrame:
     """Main function for Python API users
 
     Supports only COMPDAT information for now. Will
@@ -995,7 +999,7 @@ def df(eclfiles: EclFiles, initvectors: Optional[List[str]] = None) -> pd.DataFr
             eclfiles, compdat_df, initvectors, ijknames=["I", "J", "K1"]
         )
 
-    zonemap = eclfiles.get_zonemap()
+    zonemap = eclfiles.get_zonemap(zonemap_filename)
     if zonemap:
         logger.info("Merging zonemap into compdat")
         compdat_df = merge_zones(compdat_df, zonemap)

--- a/ecl2df/compdat.py
+++ b/ecl2df/compdat.py
@@ -986,7 +986,8 @@ def df(
     """Main function for Python API users
 
     Supports only COMPDAT information for now. Will
-    add a zone-name if a zonefile is found alongside
+    add a zone-name if a zonefile is found alongside.
+    If a zonemap is passed it will override the zonefile.
 
     Returns:
         pd.Dataframe with one row pr cell to well connection
@@ -1000,7 +1001,7 @@ def df(
         )
 
     if zonemap is None:
-        # If no zonemap is submittet, search for zonemap in default location
+        # If no zonemap is submitted, search for zonemap in default location
         zonemap = eclfiles.get_zonemap()
 
     if zonemap:

--- a/ecl2df/compdat.py
+++ b/ecl2df/compdat.py
@@ -981,7 +981,7 @@ def compdat_main(args):
 def df(
     eclfiles: EclFiles,
     initvectors: Optional[List[str]] = None,
-    zonemap_filename: Optional[str] = None,
+    zonemap: Optional[Dict[int, str]] = None,
 ) -> pd.DataFrame:
     """Main function for Python API users
 
@@ -999,7 +999,10 @@ def df(
             eclfiles, compdat_df, initvectors, ijknames=["I", "J", "K1"]
         )
 
-    zonemap = eclfiles.get_zonemap(zonemap_filename)
+    if zonemap is None:
+        # If no zonemap is submittet, search for zonemap in default location
+        zonemap = eclfiles.get_zonemap()
+
     if zonemap:
         logger.info("Merging zonemap into compdat")
         compdat_df = merge_zones(compdat_df, zonemap)

--- a/ecl2df/ecl2csv.py
+++ b/ecl2df/ecl2csv.py
@@ -207,6 +207,14 @@ def get_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description=("Each row represents an edge in the GRUPTREE at a specific date."),
     )
+    subparsers_dict["wellcompletiondata"] = subparsers.add_parser(
+        "wellcompletiondata",
+        help="Extract well completion data",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description=(
+            "Each row represents a completion, aggregated from layer to zone."
+        ),
+    )
     subparsers_dict["wellconnstatus"] = subparsers.add_parser(
         "wellconnstatus",
         help="Extract well connection status",

--- a/ecl2df/wellcompletiondata.py
+++ b/ecl2df/wellcompletiondata.py
@@ -2,20 +2,21 @@
 
 import argparse
 from pathlib import Path
+from typing import Dict
 
 import pandas as pd
 
-from ecl2df import compdat, getLogger_ecl2csv, wellconnstatus
+from ecl2df import common, compdat, getLogger_ecl2csv, wellconnstatus
 from ecl2df.eclfiles import EclFiles
 
 from .common import write_dframe_stdout_file
 
 
 def df(
-    eclfiles: EclFiles, zonemap_filename: str, use_wellconnstatus: bool
+    eclfiles: EclFiles, zonemap: Dict[int, str], use_wellconnstatus: bool
 ) -> pd.DataFrame:
     """Info"""
-    compdat_df = compdat.df(eclfiles, zonemap_filename=zonemap_filename)[
+    compdat_df = compdat.df(eclfiles, zonemap=zonemap)[
         ["DATE", "WELL", "I", "J", "K1", "OP/SH", "KH", "ZONE"]
     ]
     compdat_df["DATE"] = pd.to_datetime(compdat_df["DATE"])
@@ -131,8 +132,9 @@ def wellcompletiondata_main(args):
 
     if not Path(args.zonemap).is_file():
         raise FileNotFoundError(f"{args.zonemap} does not exists.")
+    zonemap = common.convert_lyrlist_to_zonemap(common.parse_lyrfile(args.zonemap))
 
-    wellcompletiondata_df = df(eclfiles, args.zonemap, args.use_wellconnstatus)
+    wellcompletiondata_df = df(eclfiles, zonemap, args.use_wellconnstatus)
     write_dframe_stdout_file(
         wellcompletiondata_df, args.output, index=False, caller_logger=logger
     )

--- a/ecl2df/wellcompletiondata.py
+++ b/ecl2df/wellcompletiondata.py
@@ -57,18 +57,25 @@ def df(
 
     # If excl_well_startswith is not None, filter out wells that starts with this
     if excl_well_startswith is not None:
-        keep_wells = [
-            well
-            for well in compdat_df["WELL"].unique()
-            if not well.startswith(excl_well_startswith)
-        ]
-        compdat_df = compdat_df[compdat_df["WELL"].isin(keep_wells)]
+        compdat_df = _excl_well_startswith(compdat_df, excl_well_startswith)
 
     if use_wellconnstatus:
         wellconnstatus_df = wellconnstatus.df(eclfiles)
         compdat_df = _merge_compdat_and_connstatus(compdat_df, wellconnstatus_df)
 
     return _aggregate_layer_to_zone(compdat_df)
+
+
+def _excl_well_startswith(
+    compdat_df: pd.DataFrame, excl_well_startswith: str
+) -> pd.DataFrame:
+    "Filters out rows where the well name startswith a given string"
+    keep_wells = [
+        well
+        for well in compdat_df["WELL"].unique()
+        if not well.startswith(excl_well_startswith)
+    ]
+    return compdat_df[compdat_df["WELL"].isin(keep_wells)]
 
 
 def _aggregate_layer_to_zone(compdat_df: pd.DataFrame) -> pd.DataFrame:

--- a/ecl2df/wellcompletiondata.py
+++ b/ecl2df/wellcompletiondata.py
@@ -1,23 +1,25 @@
 """Aggregates completion data from layer to zone"""
 
 import argparse
-import logging
 from pathlib import Path
-from typing import Any, List
 
 import pandas as pd
 
-from ecl2df import compdat, getLogger_ecl2csv
+from ecl2df import compdat, getLogger_ecl2csv, wellconnstatus
 from ecl2df.eclfiles import EclFiles
 
 from .common import write_dframe_stdout_file
 
-logger = logging.getLogger(__name__)
 
-
-def df(eclfiles: EclFiles, zonemap_filename: str) -> pd.DataFrame:
+def df(
+    eclfiles: EclFiles, zonemap_filename: str, use_wellconnstatus: bool
+) -> pd.DataFrame:
     """Info"""
     compdat_df = compdat.df(eclfiles, zonemap_filename=zonemap_filename)
+
+    if use_wellconnstatus:
+        wellconnstatus_df = wellconnstatus.df(eclfiles)
+        compdat_df = _merge_compdat_and_connstatus(compdat_df, wellconnstatus_df)
 
     records = []
     for (well, zone, date), group_df in compdat_df.groupby(["WELL", "ZONE", "DATE"]):
@@ -33,6 +35,45 @@ def df(eclfiles: EclFiles, zonemap_filename: str) -> pd.DataFrame:
             }
         )
     return pd.DataFrame(records)
+
+
+def _merge_compdat_and_connstatus(
+    compdat_df: pd.DataFrame, wellconnstatus_df: pd.DataFrame
+) -> pd.DataFrame:
+    """This function merges the compdat data with the well connection status data
+    (extracted from the CPI summary data). The connection status data will be used
+    for wells where it exists. The KH will be merged from the compdat. For wells
+    that are not in the connection status data, the compdat data will be used as it is.
+
+    This approach is fast, but a couple of things should be noted:
+    * in the connection status data, a connection is not set to SHUT before it has been
+    OPEN. In the compdat data, some times all connections are first defined and the
+    opened later.
+    * any connections that are in compdat but not in connections status will be ignored
+    (e.g. connections that are always shut)
+    * there is no logic to handle KH changing with time for the same connection (this
+    can easily be added using apply in pandas, but it is very rare and slows down the
+    function significantly)
+    * if connection status is missing for a realization, but compdat exists, compdat
+    will also be ignored.
+    """
+    match_on = ["REAL", "WELL", "I", "J", "K1"]
+    dframe = pd.merge(
+        wellconnstatus_df, compdat_df[match_on + ["KH"]], on=match_on, how="left"
+    )
+
+    # There will often be several rows (with different OP/SH) matching in compdat.
+    # Only the first is kept
+    dframe.drop_duplicates(subset=["DATE"] + match_on, keep="first", inplace=True)
+
+    # Concat from compdat the wells that are not in well connection status
+    dframe = pd.concat(
+        [dframe, compdat_df[~compdat_df.WELL.isin(dframe["WELL"].unique())]]
+    )
+
+    dframe = dframe.reset_index(drop=True)
+    dframe["KH"] = dframe["KH"].fillna(0)
+    return dframe
 
 
 def fill_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
@@ -79,7 +120,7 @@ def wellcompletiondata_main(args):
     if not Path(args.zonemap).is_file():
         raise FileNotFoundError(f"{args.zonemap} does not exists.")
 
-    wellcompletiondata_df = df(eclfiles, args.zonemap)
+    wellcompletiondata_df = df(eclfiles, args.zonemap, args.use_wellconnstatus)
     write_dframe_stdout_file(
         wellcompletiondata_df, args.output, index=False, caller_logger=logger
     )

--- a/ecl2df/wellcompletiondata.py
+++ b/ecl2df/wellcompletiondata.py
@@ -69,7 +69,7 @@ def df(
 def _excl_well_startswith(
     compdat_df: pd.DataFrame, excl_well_startswith: str
 ) -> pd.DataFrame:
-    "Filters out rows where the well name startswith a given string"
+    """Filters out rows where the well name starts with a given string"""
     keep_wells = [
         well
         for well in compdat_df["WELL"].unique()

--- a/ecl2df/wellcompletiondata.py
+++ b/ecl2df/wellcompletiondata.py
@@ -19,10 +19,16 @@ def df(
         ["DATE", "WELL", "I", "J", "K1", "OP/SH", "KH", "ZONE"]
     ]
     compdat_df["DATE"] = pd.to_datetime(compdat_df["DATE"])
+
     if use_wellconnstatus:
         wellconnstatus_df = wellconnstatus.df(eclfiles)
         compdat_df = _merge_compdat_and_connstatus(compdat_df, wellconnstatus_df)
 
+    return _aggregate_layer_to_zone(compdat_df)
+
+
+def _aggregate_layer_to_zone(compdat_df: pd.DataFrame) -> pd.DataFrame:
+    """Descr"""
     records = []
     for (well, zone, date), group_df in compdat_df.groupby(["WELL", "ZONE", "DATE"]):
         open_compl_df = group_df[group_df["OP/SH"] == "OPEN"]

--- a/ecl2df/wellcompletiondata.py
+++ b/ecl2df/wellcompletiondata.py
@@ -61,8 +61,6 @@ def _merge_compdat_and_connstatus(
     """
     match_on = ["WELL", "I", "J", "K1"]
     wellconnstatus_df.rename({"K": "K1"}, axis=1, inplace=True)
-    print(compdat_df)
-    print(wellconnstatus_df)
 
     dframe = pd.merge(
         wellconnstatus_df,

--- a/ecl2df/wellcompletiondata.py
+++ b/ecl2df/wellcompletiondata.py
@@ -1,0 +1,85 @@
+"""Aggregates completion data from layer to zone"""
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Any, List
+
+import pandas as pd
+
+from ecl2df import compdat, getLogger_ecl2csv
+from ecl2df.eclfiles import EclFiles
+
+from .common import write_dframe_stdout_file
+
+logger = logging.getLogger(__name__)
+
+
+def df(eclfiles: EclFiles, zonemap_filename: str) -> pd.DataFrame:
+    """Info"""
+    compdat_df = compdat.df(eclfiles, zonemap_filename=zonemap_filename)
+
+    records = []
+    for (well, zone, date), group_df in compdat_df.groupby(["WELL", "ZONE", "DATE"]):
+        open_compl_df = group_df[group_df["OP/SH"] == "OPEN"]
+        has_open_compl = open_compl_df.shape[0] > 0
+        records.append(
+            {
+                "WELL": well,
+                "ZONE": zone,
+                "DATE": date,
+                "KH": open_compl_df["KH"].sum() if has_open_compl else 0,
+                "OP/SH": "OPEN" if has_open_compl else "SHUT",
+            }
+        )
+    return pd.DataFrame(records)
+
+
+def fill_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Set up sys.argv parsers.
+
+    Arguments:
+        parser: parser to fill with arguments
+    """
+    parser.add_argument(
+        "DATAFILE",
+        type=str,
+        help="Name of Eclipse DATA file. " + "UNSMRY file must lie alongside.",
+    )
+    parser.add_argument(
+        "--zonemap",
+        type=str,
+        help=("Name of lyr file with layer->zone mapping"),
+        default="rms/output/zone/simgrid_zone_layer_mapping.lyr",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        help=(
+            "Name of output csv file. Use '-' to write to stdout. "
+            "Default 'well_completion_data.csv'"
+        ),
+        default="well_completion_data.csv",
+    )
+    parser.add_argument(
+        "--use_wellconnstatus",
+        action="store_true",
+        help="Use well connection status extracted from CPI* summary data.",
+    )
+    parser.add_argument("--arrow", action="store_true", help="Write to pyarrow format")
+    return parser
+
+
+def wellcompletiondata_main(args):
+    """Entry-point for module, for command line utility"""
+    logger = getLogger_ecl2csv(__name__, vars(args))
+    eclfiles = EclFiles(args.DATAFILE)
+
+    if not Path(args.zonemap).is_file():
+        raise FileNotFoundError(f"{args.zonemap} does not exists.")
+
+    wellcompletiondata_df = df(eclfiles, args.zonemap)
+    write_dframe_stdout_file(
+        wellcompletiondata_df, args.output, index=False, caller_logger=logger
+    )

--- a/ecl2df/wellconnstatus.py
+++ b/ecl2df/wellconnstatus.py
@@ -54,6 +54,10 @@ def _extract_status_changes(smry: pd.DataFrame) -> pd.DataFrame:
         for date, status in status_changes:
             dframe.loc[dframe.shape[0]] = [date, well, i, j, k, status]
 
+    dframe["I"] = dframe["I"].astype(int)
+    dframe["J"] = dframe["J"].astype(int)
+    dframe["K"] = dframe["K"].astype(int)
+
     logger.info(
         "Dataframe with well connection status ready, %d rows",
         len(dframe),

--- a/tests/test_wellcompletiondata.py
+++ b/tests/test_wellcompletiondata.py
@@ -1,0 +1,60 @@
+import datetime
+from pathlib import Path
+
+import pandas as pd
+
+from ecl2df import wellcompletiondata
+from ecl2df.eclfiles import EclFiles
+
+try:
+    import opm  # noqa
+
+    HAVE_OPM = True
+except ImportError:
+    HAVE_OPM = False
+
+TESTDIR = Path(__file__).absolute().parent
+EIGHTCELLS = str(TESTDIR / "data/eightcells/EIGHTCELLS.DATA")
+EIGHTCELLS_ZONEMAP = str(TESTDIR / "data/eightcells/zones.lyr")
+
+
+def test_eightcells_dataset():
+    """Test Eightcells dataset."""
+    eclfiles = EclFiles(EIGHTCELLS)
+    expected_dframe = pd.DataFrame(
+        [
+            {
+                "WELL": "OP1",
+                "ZONE": "Upper",
+                "DATE": datetime.datetime(year=2000, month=1, day=2),
+                "KH": -1,
+                "OP/SH": "OPEN",
+            }
+        ]
+    )
+    pd.testing.assert_frame_equal(
+        wellcompletiondata.df(
+            eclfiles, zonemap_filename=EIGHTCELLS_ZONEMAP, use_wellconnstatus=True
+        ),
+        expected_dframe,
+        check_dtype=False,
+    )
+
+    expected_dframe = pd.DataFrame(
+        [
+            {
+                "WELL": "OP1",
+                "ZONE": "Upper",
+                "DATE": datetime.datetime(year=2000, month=1, day=1),
+                "KH": -1,
+                "OP/SH": "OPEN",
+            }
+        ]
+    )
+    pd.testing.assert_frame_equal(
+        wellcompletiondata.df(
+            eclfiles, zonemap_filename=EIGHTCELLS_ZONEMAP, use_wellconnstatus=False
+        ),
+        expected_dframe,
+        check_dtype=False,
+    )

--- a/tests/test_wellcompletiondata.py
+++ b/tests/test_wellcompletiondata.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from ecl2df import wellcompletiondata
+from ecl2df import common, wellcompletiondata
 from ecl2df.eclfiles import EclFiles
 from ecl2df.wellcompletiondata import _merge_compdat_and_connstatus
 
@@ -17,7 +17,10 @@ except ImportError:
 
 TESTDIR = Path(__file__).absolute().parent
 EIGHTCELLS = str(TESTDIR / "data/eightcells/EIGHTCELLS.DATA")
-EIGHTCELLS_ZONEMAP = str(TESTDIR / "data/eightcells/zones.lyr")
+# EIGHTCELLS_ZONEMAP = str(TESTDIR / "data/eightcells/zones.lyr")
+EIGHTCELLS_ZONEMAP = common.convert_lyrlist_to_zonemap(
+    common.parse_lyrfile(str(TESTDIR / "data/eightcells/zones.lyr"))
+)
 
 
 def test_eightcells_with_wellconnstatus():
@@ -38,7 +41,7 @@ def test_eightcells_with_wellconnstatus():
     )
     pd.testing.assert_frame_equal(
         wellcompletiondata.df(
-            eclfiles, zonemap_filename=EIGHTCELLS_ZONEMAP, use_wellconnstatus=True
+            eclfiles, zonemap=EIGHTCELLS_ZONEMAP, use_wellconnstatus=True
         ),
         expected_dframe,
         check_dtype=False,
@@ -62,7 +65,7 @@ def test_eightcells_without_wellconnstatus():
     )
     pd.testing.assert_frame_equal(
         wellcompletiondata.df(
-            eclfiles, zonemap_filename=EIGHTCELLS_ZONEMAP, use_wellconnstatus=False
+            eclfiles, zonemap=EIGHTCELLS_ZONEMAP, use_wellconnstatus=False
         ),
         expected_dframe,
         check_dtype=False,

--- a/tests/test_wellcompletiondata.py
+++ b/tests/test_wellcompletiondata.py
@@ -9,6 +9,7 @@ from ecl2df import common, compdat, wellcompletiondata
 from ecl2df.eclfiles import EclFiles
 from ecl2df.wellcompletiondata import (
     _aggregate_layer_to_zone,
+    _excl_well_startswith,
     _merge_compdat_and_connstatus,
 )
 
@@ -244,8 +245,32 @@ CASES = [
 @pytest.mark.parametrize("compdat_df, wellcompletion_df", CASES)
 def test_aggregate_layer_to_zone(compdat_df, wellcompletion_df):
     """Tests the _aggregate_layer_to_zone function in wellcompletionsdata"""
-    print(compdat_df)
-    print(wellcompletion_df)
     pd.testing.assert_frame_equal(
         _aggregate_layer_to_zone(compdat_df), wellcompletion_df, check_like=True
+    )
+
+
+def test_excl_well_startswith():
+    """Tests the _excl_well_startswith function in wellcompletiondata.
+    Only the well that starts with R_ is filtered out.
+    """
+    input_df = pd.DataFrame(
+        columns=["DATE", "WELL", "I", "J", "K1", "OP/SH", "KH", "ZONE"],
+        data=[
+            [datetime(year=2000, month=1, day=1), "OP1", 1, 1, 1, "OPEN", 1, "Z1"],
+            [datetime(year=2000, month=1, day=1), "R_OP1", 1, 1, 1, "OPEN", 1, "Z1"],
+            [datetime(year=2000, month=1, day=1), "OP1R_", 1, 1, 1, "OPEN", 1, "Z1"],
+        ],
+    )
+    expected_df = pd.DataFrame(
+        columns=["DATE", "WELL", "I", "J", "K1", "OP/SH", "KH", "ZONE"],
+        data=[
+            [datetime(year=2000, month=1, day=1), "OP1", 1, 1, 1, "OPEN", 1, "Z1"],
+            [datetime(year=2000, month=1, day=1), "OP1R_", 1, 1, 1, "OPEN", 1, "Z1"],
+        ],
+    )
+    pd.testing.assert_frame_equal(
+        _excl_well_startswith(input_df, "R_").reset_index(drop=True),
+        expected_df,
+        check_like=True,
     )

--- a/tests/test_wellcompletiondata.py
+++ b/tests/test_wellcompletiondata.py
@@ -72,6 +72,13 @@ def test_eightcells_without_wellconnstatus():
     )
 
 
+def test_empty_zonemap():
+    """Test empty zonemap"""
+    eclfiles = EclFiles(EIGHTCELLS)
+    df = wellcompletiondata.df(eclfiles, zonemap={}, use_wellconnstatus=False)
+    assert df.empty
+
+
 def test_merge_compdat_and_connstatus():
     """Tests the functionality of the merge_compdat_and_connstatus function.
 

--- a/tests/test_wellcompletiondata.py
+++ b/tests/test_wellcompletiondata.py
@@ -9,6 +9,7 @@ from ecl2df import common, compdat, wellcompletiondata
 from ecl2df.eclfiles import EclFiles
 from ecl2df.wellcompletiondata import (
     _aggregate_layer_to_zone,
+    _df2pyarrow,
     _excl_well_startswith,
     _merge_compdat_and_connstatus,
 )
@@ -76,6 +77,16 @@ def test_eightcells_without_wellconnstatus():
         expected_dframe,
         check_dtype=False,
     )
+
+
+def test_df2pyarrow():
+    """Test that dataframe is conserved using _df2pyarrow"""
+    eclfiles = EclFiles(EIGHTCELLS)
+    df = wellcompletiondata.df(
+        eclfiles, zonemap=EIGHTCELLS_ZONEMAP, use_wellconnstatus=False
+    )
+    df["KH"] = df["KH"].astype(np.int32)
+    pd.testing.assert_frame_equal(df, _df2pyarrow(df).to_pandas(), check_like=True)
 
 
 def test_empty_zonemap():

--- a/tests/test_wellcompletiondata.py
+++ b/tests/test_wellcompletiondata.py
@@ -243,7 +243,7 @@ CASES = [
 
 @pytest.mark.parametrize("compdat_df, wellcompletion_df", CASES)
 def test_aggregate_layer_to_zone(compdat_df, wellcompletion_df):
-    """Descr"""
+    """Tests the _aggregate_layer_to_zone function in wellcompletionsdata"""
     print(compdat_df)
     print(wellcompletion_df)
     pd.testing.assert_frame_equal(

--- a/tests/test_wellcompletiondata.py
+++ b/tests/test_wellcompletiondata.py
@@ -1,10 +1,12 @@
 import datetime
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 from ecl2df import wellcompletiondata
 from ecl2df.eclfiles import EclFiles
+from ecl2df.wellcompletiondata import _merge_compdat_and_connstatus
 
 try:
     import opm  # noqa
@@ -18,8 +20,10 @@ EIGHTCELLS = str(TESTDIR / "data/eightcells/EIGHTCELLS.DATA")
 EIGHTCELLS_ZONEMAP = str(TESTDIR / "data/eightcells/zones.lyr")
 
 
-def test_eightcells_dataset():
-    """Test Eightcells dataset."""
+def test_eightcells_with_wellconnstatus():
+    """Test the Eightcells dataset with the well connection status
+    option activated (connection status extracted from summary data)
+    """
     eclfiles = EclFiles(EIGHTCELLS)
     expected_dframe = pd.DataFrame(
         [
@@ -40,6 +44,11 @@ def test_eightcells_dataset():
         check_dtype=False,
     )
 
+
+def test_eightcells_without_wellconnstatus():
+    """Test the Eightcells dataset with only the compdat export data (connection
+    status extracted from parsing the schedule file)"""
+    eclfiles = EclFiles(EIGHTCELLS)
     expected_dframe = pd.DataFrame(
         [
             {
@@ -58,3 +67,68 @@ def test_eightcells_dataset():
         expected_dframe,
         check_dtype=False,
     )
+
+
+def test_merge_compdat_and_connstatus():
+    """Tests the functionality of the merge_compdat_and_connstatus function.
+
+    The following functionality is covered:
+    * The two first rows of df_compdat is replaced with the two first from
+    df_connstatus, except for the KH (which is only available in df_compdat).
+    KH is taken from the first of the two compdat rows
+    * The A2 well is not available in df_connstatus and will be taken as is
+    from df_compdat
+    * the fourth row in df_compdat (WELL: A1, REAL:1) is ignored because A1 is
+    in df_connstatus, but not REAL 1. We don't mix compdat and connstatus data
+    for the same well
+    * The fourth row in df_compdat has KH=Nan. This will be 0 in the output
+    """
+    df_compdat = pd.DataFrame(
+        data={
+            "DATE": [
+                "2021-01-01",
+                "2021-05-01",
+                "2021-01-01",
+                "2021-01-01",
+                "2022-01-01",
+            ],
+            "REAL": [0, 0, 0, 1, 0],
+            "WELL": ["A1", "A1", "A2", "A1", "A3"],
+            "I": [1, 1, 1, 1, 1],
+            "J": [1, 1, 1, 1, 1],
+            "K1": [1, 1, 1, 1, 1],
+            "OP/SH": ["SHUT", "OPEN", "OPEN", "OPEN", "OPEN"],
+            "KH": [100, 1000, 10, 100, np.nan],
+            "ZONE": ["ZONE1", "ZONE1", "ZONE1", "ZONE1", "ZONE1"],
+        }
+    )
+    df_connstatus = pd.DataFrame(
+        data={
+            "DATE": ["2021-03-01", "2021-08-01", "2021-01-01"],
+            "REAL": [0, 0, 0],
+            "WELL": ["A1", "A1", "A3"],
+            "I": [1, 1, 1],
+            "J": [1, 1, 1],
+            "K1": [1, 1, 1],
+            "OP/SH": ["OPEN", "SHUT", "OPEN"],
+        }
+    )
+    df_output = pd.DataFrame(
+        data={
+            "DATE": ["2021-03-01", "2021-08-01", "2021-01-01", "2021-01-01"],
+            "REAL": [0, 0, 0, 0],
+            "WELL": ["A1", "A1", "A3", "A2"],
+            "I": [1, 1, 1, 1],
+            "J": [1, 1, 1, 1],
+            "K1": [1, 1, 1, 1],
+            "OP/SH": ["OPEN", "SHUT", "OPEN", "OPEN"],
+            "KH": [100.0, 100.0, 0.0, 10.0],
+            "ZONE": ["ZONE1", "ZONE1", "ZONE1", "ZONE1"],
+        }
+    )
+    df_compdat["DATE"] = pd.to_datetime(df_compdat["DATE"])
+    df_connstatus["DATE"] = pd.to_datetime(df_connstatus["DATE"])
+    df_output["DATE"] = pd.to_datetime(df_output["DATE"])
+
+    df_result = _merge_compdat_and_connstatus(df_compdat, df_connstatus)
+    pd.testing.assert_frame_equal(df_result, df_output, check_like=True)

--- a/tests/test_wellcompletiondata.py
+++ b/tests/test_wellcompletiondata.py
@@ -14,10 +14,11 @@ from ecl2df.wellcompletiondata import (
 
 try:
     import opm  # noqa
-
-    HAVE_OPM = True
 except ImportError:
-    HAVE_OPM = False
+    pytest.skip(
+        "OPM is not installed",
+        allow_module_level=True,
+    )
 
 TESTDIR = Path(__file__).absolute().parent
 EIGHTCELLS = str(TESTDIR / "data/eightcells/EIGHTCELLS.DATA")

--- a/tests/test_wellconnstatus.py
+++ b/tests/test_wellconnstatus.py
@@ -36,9 +36,9 @@ def test_eightcells_dataset():
             {
                 "DATE": "2000-01-02",
                 "WELL": "OP1",
-                "I": "1",
-                "J": "1",
-                "K": "1",
+                "I": 1,
+                "J": 1,
+                "K": 1,
                 "OP/SH": "OPEN",
             }
         ],
@@ -62,7 +62,7 @@ def test_eightcells_dataset():
             ),
             pd.DataFrame(
                 [
-                    ["2000-01-02", "OP1", "1", "1", "1", "OPEN"],
+                    ["2000-01-02", "OP1", 1, 1, 1, "OPEN"],
                 ],
                 columns=["DATE", "WELL", "I", "J", "K", "OP/SH"],
             ),
@@ -79,8 +79,8 @@ def test_eightcells_dataset():
             ),
             pd.DataFrame(
                 [
-                    ["2000-01-01", "OP1", "1", "1", "2", "OPEN"],
-                    ["2000-01-02", "OP1", "1", "1", "2", "SHUT"],
+                    ["2000-01-01", "OP1", 1, 1, 2, "OPEN"],
+                    ["2000-01-02", "OP1", 1, 1, 2, "SHUT"],
                 ],
                 columns=["DATE", "WELL", "I", "J", "K", "OP/SH"],
             ),
@@ -97,9 +97,9 @@ def test_eightcells_dataset():
             ),
             pd.DataFrame(
                 [
-                    ["2000-01-01", "OP1", "1", "1", "1", "OPEN"],
-                    ["2000-01-02", "OP1", "1", "1", "1", "SHUT"],
-                    ["2000-01-02 12:00:00", "OP2", "1", "1", "1", "OPEN"],
+                    ["2000-01-01", "OP1", 1, 1, 1, "OPEN"],
+                    ["2000-01-02", "OP1", 1, 1, 1, "SHUT"],
+                    ["2000-01-02 12:00:00", "OP2", 1, 1, 1, "OPEN"],
                 ],
                 columns=["DATE", "WELL", "I", "J", "K", "OP/SH"],
             ),


### PR DESCRIPTION
New module `wellcompletiondata ` that uses both the `compdat` and `wellconnstatus` modules and combines this data with a layer->zone mapping `.lyr` file. The output is a table of well completion data on zone level with the following columns: WELL, ZONE, DATE, KH and OP/SH.

This is functionality was previously implemented in the `WellCompletion` plugin in `webviz-subsurface`. The reason for moving it here is to improve speed and prepare for additional functionality in the plugin. An additional advantage is that it's not necessary to export `compdat` and `wellconnstatus` to use the plugin, so less data might be exported. AND it will be easier to use the `wellconnstatus` functionality.