### PR TITLE
Set python 3.10 version to 3.10.5

### DIFF
--- a/.github/workflows/ecl2df.yml
+++ b/.github/workflows/ecl2df.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10.5']
         include:
           # For one of the Python versions we
           # install the extra dependency ert


### PR DESCRIPTION
There is an issue with `mypy` in python 3.10.7 which is supposed to be solved in coming releases of `mypy`. But we need to temporarily lock the python 3.10 version to 3.10.5.