### PR TITLE
Bug fix. Changed from r to w in file open.

### DIFF
--- a/ecl2df/vfp/_vfp.py
+++ b/ecl2df/vfp/_vfp.py
@@ -402,8 +402,9 @@ def df2ecl(
         str_vfps += "\n"
 
     if filename:
-        with open(filename, "r") as fout:
+        with open(filename, "w") as fout:
             fout.write(str_vfp)
+
     return str_vfps
 
 


### PR DESCRIPTION
Support for Eclipse VFP curves (VFPPROD/VFPINJ) in ecl2df. Supports output as pandas DataFrame or pyarrow Table. Also support for df2ecl to convert pandas DataFrame back to Eclipse format (.Ecl) for liftcurves.