### PR TITLE
Breaking: `ecl2csv summary.df` arg `include_restart` default changed to `False`

### DIFF
--- a/.github/workflows/ecl2df.yml
+++ b/.github/workflows/ecl2df.yml
@@ -12,13 +12,12 @@ on:
       - published
   schedule:
     # Run CI every night and check that tests are working with latest dependencies
-    - cron:  '0 0 * * *'
+    - cron: '0 0 * * *'
 
 env:
   ERT_SHOW_BACKTRACE: 1
 
 jobs:
-
   ecl2df:
     runs-on: ubuntu-18.04
     strategy:
@@ -112,3 +111,4 @@ jobs:
           python -m pip install --upgrade setuptools wheel twine
           python setup.py sdist bdist_wheel
           twine upload dist/*
+

--- a/docs/usage/summary.rst
+++ b/docs/usage/summary.rst
@@ -20,6 +20,10 @@ Eclipse equivalent to ``time_index="raw"``, other options are *daily*, *weekly*,
 *monthly* or *yearly*.  See below for how to interpred "interpolated" summary
 data.
 
+Additional arguments are available, see the
+`API documentation <https://equinor.github.io/ecl2df/ecl2df/ecl2df.summary.html#ecl2df.summary.df>`_
+for an extensive overview.
+
 .. csv-table:: Example summary table
    :file: summary.csv
    :header-rows: 1

--- a/ecl2df/summary.py
+++ b/ecl2df/summary.py
@@ -869,6 +869,7 @@ def fill_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         default="summary.csv",
     )
     parser.add_argument("--arrow", action="store_true", help="Write to pyarrow format")
+    parser.add_argument("--include_restart", action="store_true", help="Attempt to include data from before restart")
 
     parser.add_argument("-v", "--verbose", action="store_true", help="Be verbose")
     return parser
@@ -906,6 +907,7 @@ def summary_main(args) -> None:
         column_keys=args.column_keys,
         start_date=args.start_date,
         end_date=args.end_date,
+        include_restart=args.include_restart,
         params=args.params,
         paramfile=args.paramfile,
         datetime=False,

--- a/ecl2df/summary.py
+++ b/ecl2df/summary.py
@@ -302,7 +302,7 @@ def df(
     column_keys: Union[List[str], str] = None,
     start_date: Optional[Union[str, dt.date]] = None,
     end_date: Optional[Union[str, dt.date]] = None,
-    include_restart: bool = True,
+    include_restart: bool = False,
     params: bool = False,
     paramfile: Optional[str] = None,
     datetime: bool = False,  # A very poor choice of argument name [pylint]
@@ -336,7 +336,7 @@ def df(
             Dates past this date will be dropped, supplied
             end_date will always be included. Overriden if time_index
             is 'last'.
-        include_restart: boolean sent to libecl for wheter restarts
+        include_restart: boolean sent to libecl for whether restart
             files should be traversed
         params: If set, parameters.txt will be attempted loaded
             and merged with the summary data.

--- a/ecl2df/summary.py
+++ b/ecl2df/summary.py
@@ -869,7 +869,11 @@ def fill_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         default="summary.csv",
     )
     parser.add_argument("--arrow", action="store_true", help="Write to pyarrow format")
-    parser.add_argument("--include_restart", action="store_true", help="Attempt to include data from before restart")
+    parser.add_argument(
+        "--include_restart",
+        action="store_true",
+        help="Attempt to include data from before restart",
+    )
 
     parser.add_argument("-v", "--verbose", action="store_true", help="Be verbose")
     return parser


### PR DESCRIPTION
Resolves #419 

This is a suggestion. It is a breaking change. On the other hand, the data from prior to restart is only included today if the path is less than a certain number of characters, so it is not completely stable. Therefore think it might be better to have a stable default and rather make the user able to request restart data if necessary.