### PR TITLE
Set python 3.10.5 back to 3.10

### DIFF
--- a/.github/workflows/ecl2df.yml
+++ b/.github/workflows/ecl2df.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10.5']
+        python-version: ['3.8', '3.9', '3.10']
         include:
           # For one of the Python versions we
           # install the extra dependency ert


### PR DESCRIPTION
Python 3.10 version was set to 3.10.5 because of a `mypy` error. This should be fixed in the next version of `mypy` and then this PR can be merged.