### PR TITLE
[summary] FIX: Ensure index name is retained

### DIFF
--- a/ecl2df/summary.py
+++ b/ecl2df/summary.py
@@ -483,7 +483,7 @@ def _ensure_unique_datetime_index(dframe: pd.DataFrame) -> pd.DataFrame:
                     "Dataframe of smry data contained duplicate timestamps",
                     "Vector TIMESTEP exists, but unit could not be identified",
                 )
-            dframe.index = index_as_list
+            dframe.index = pd.Series(data=index_as_list, name=dframe.index.name)
         else:
             raise ValueError(
                 "Dataframe of smry data contained duplicate timestamps due to limited.",

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -804,7 +804,7 @@ def test_unique_datetime_for_short_timesteps(filepath):
 )
 def test_unique_datetime_retain_index_name(filepath):
     """Test _ensure_unique_datetime_index method retain index name"""
-    assert summary.df(EclFiles(filepath)).index.name is not None
+    assert summary.df(EclFiles(filepath)).index.name == "DATE"
 
 
 def test_smry_meta():

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -795,6 +795,18 @@ def test_unique_datetime_for_short_timesteps(filepath):
     assert summary.df(EclFiles(filepath)).index.is_unique
 
 
+@pytest.mark.parametrize(
+    "filepath",
+    [
+        SHORT_STEP_WITH_TIMESTEP,
+        SHORT_STEP_WITH_TIMESTEP_LONG,
+    ],
+)
+def test_unique_datetime_retain_index_name(filepath):
+    """Test _ensure_unique_datetime_index method retain index name"""
+    assert summary.df(EclFiles(filepath)).index.name is not None
+
+
 def test_smry_meta():
     """Test obtaining metadata dictionary for summary vectors from an EclSum object"""
     meta = smry_meta(EclFiles(REEK))


### PR DESCRIPTION
This PR fixes issue #423 where data frame index header name is set to None when the index is replace with list. It makes the generated CSV file unusable for WebViz since WebViz cannot fine the column.