### PR TITLE
Use all accessible ports for ERT on local queue

### DIFF
--- a/tests/test_ert_hooks.py
+++ b/tests/test_ert_hooks.py
@@ -92,7 +92,9 @@ def test_ecl2csv_through_ert(tmp_path):
     ert_config_filename = "ecl2csv_test.ert"
     Path(ert_config_filename).write_text("\n".join(ert_config), encoding="utf-8")
 
-    subprocess.call(["ert", "test_run", ert_config_filename])
+    subprocess.call(
+        ["ert", "test_run", "--port-range", "1024-65535", ert_config_filename]
+    )
 
     assert Path("OK").is_file()
 


### PR DESCRIPTION
If not, ERT will pick a port in the default range 51820-51840 for which should be saved for ERT runs over the network. When running tests in parallel, using the limited range exposes the tests to port starvation.