### PR TITLE
Pin pydantic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ DOCS_REQUIREMENTS = [
     "autoapi",
     "ipython",
     "rstcheck",
+    "pydantic<2",  # remove this when ert unpins fastapi and pydantic
     "sphinx<7",
     "sphinx-argparse",
     "sphinx-autodoc-typehints",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ DOCS_REQUIREMENTS = [
     "autoapi",
     "ipython",
     "rstcheck",
-    "sphinx",
+    "sphinx<7",
     "sphinx-argparse",
     "sphinx-autodoc-typehints",
     "sphinx_rtd_theme",


### PR DESCRIPTION
newest pydantic is pulled in by rstcheck. ert requires pydantic<2