### PR TITLE
Ensure some actions are trigger only for pandas>2

### DIFF
--- a/.github/workflows/res2df.yml
+++ b/.github/workflows/res2df.yml
@@ -79,7 +79,7 @@ jobs:
           python setup.py build_sphinx
 
       - name: Update GitHub pages
-        if: github.repository_owner == 'equinor' && github.ref == 'refs/heads/master' && matrix.python-version == '3.8'
+        if: github.repository_owner == 'equinor' && github.ref == 'refs/heads/master' && matrix.python-version == '3.8' && matrix.pandas-version == 'pandas>2'
         run: |
             cp -R ./build/sphinx/html ../html
 
@@ -102,7 +102,7 @@ jobs:
             fi
 
       - name: Build python package and publish to pypi
-        if: github.event_name == 'release' && matrix.python-version == '3.8'
+        if: github.event_name == 'release' && matrix.python-version == '3.8' && matrix.pandas-version == 'pandas>2'
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.res2df_pypi_token }}


### PR DESCRIPTION
In PR #461 I have added `pandas-version` to the test matrix but that causes issue in the github action `Update GitHub pages` and potentially `Build python package and publish to pypi`

Add condition: `matrix.pandas-version == 'pandas>2'` to the action