### PR TITLE
Make sure PORV column is only processed once in init2df

### DIFF
--- a/src/res2df/grid.py
+++ b/src/res2df/grid.py
@@ -438,13 +438,12 @@ def init2df(
     usevectors = []
     include_porv = False
     for vec in init.headers:
-        if vec[1] == egrid.getNumActive() and any(
+        if vec[0] == "PORV" and any(fnmatch.fnmatch("PORV", key) for key in vectors):
+            include_porv = True
+        elif vec[1] == egrid.getNumActive() and any(
             fnmatch.fnmatch(vec[0], key) for key in vectors
         ):
             usevectors.append(vec[0])
-        if vec[0] == "PORV" and any(fnmatch.fnmatch("PORV", key) for key in vectors):
-            include_porv = True
-
     if usevectors:
         init_df = pd.DataFrame(
             columns=usevectors,
@@ -465,8 +464,6 @@ def init2df(
     else:
         init_df = pd.DataFrame()  # empty
 
-    logger.info("Extracted %s from INIT file", str(init_df.columns.values))
-
     # PORV is indexed by active_index, not global, needs special treatment:
     if include_porv:
         porv_numpy = init.iget_named_kw("PORV", 0).numpyView()
@@ -474,7 +471,8 @@ def init2df(
             egrid.get_global_index(active_index=ix)
             for ix in range(egrid.getNumActive())
         ]
-        init_df["PORV"] = porv_numpy[glob_idxs].reshape(-1, 1)
+        init_df["PORV"] = porv_numpy[glob_idxs]
+    logger.info("Extracted %s from INIT file", str(init_df.columns.values))
     return init_df
 
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -9,8 +9,7 @@ import pandas as pd
 import pyarrow
 import pytest
 
-from res2df import common, grid, res2csv
-from res2df.resdatafiles import ResdataFiles
+from res2df import ResdataFiles, common, grid, res2csv
 
 TESTDIR = Path(__file__).absolute().parent
 REEK = str(TESTDIR / "data/reek/eclipse/model/2_R001_REEK-0.DATA")
@@ -163,6 +162,17 @@ def test_init2df():
         assert np.isnan(init_df["KRO"].unique()).all()
 
 
+def test_that_init2df_works_with_only_PORV():
+    """Test that requesting only PORV works"""
+    resdatafiles = ResdataFiles(REEK)
+    init_df = grid.init2df(resdatafiles, vectors="PORV")
+
+    assert isinstance(init_df, pd.DataFrame)
+    # pylint: disable=unsupported-membership-test  # false positive on Dataframe
+    assert not init_df.empty
+    assert "PORV" in init_df
+
+
 def test_grid_df():
     """Test that dataframe with INIT vectors and coordinates can be produced"""
     resdatafiles = ResdataFiles(EIGHTCELLS)
@@ -187,6 +197,16 @@ def test_grid_df():
         / sum(grid_df["PORV"])
         < 0.00001
     )
+
+
+def test_that_grid_df_works_with_only_PORV():
+    """Test that dataframe with INIT vector PORV works"""
+    resdatafiles = ResdataFiles(EIGHTCELLS)
+    grid_df = grid.df(resdatafiles, vectors="PORV")
+
+    assert isinstance(grid_df, pd.DataFrame)
+    assert not grid_df.empty
+    assert "PORV" in grid_df
 
 
 def test_df2res(tmp_path):


### PR DESCRIPTION
Resolves #517 

Difficult to say if this pr resolves the exact same issue that is reported since the information is quite sparse, but the tests added in this pr reproduce the exact same error message, which happens when one tries to add the PORO column of shape (-1,1) to an empty pandas dataframe. Reshaping it should not be necessary since pandas expect a 1d numpy array.