### PR TITLE
Fix pyarrow.feather not available

### DIFF
--- a/src/res2df/common.py
+++ b/src/res2df/common.py
@@ -19,6 +19,9 @@ import dateutil.parser
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+from pyarrow import (
+    feather,  # necessary as this module is not loaded unless explicitly imported
+)
 
 try:
     import opm.io.deck
@@ -150,7 +153,7 @@ def write_dframe_stdout_file(
         if isinstance(dframe, pd.DataFrame):
             dframe.to_csv(output, index=index)
         else:
-            pa.feather.write_feather(dframe, dest=output)
+            feather.write_feather(dframe, dest=output)
 
 
 def write_inc_stdout_file(string: str, outputfilename: str) -> None:

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
-from pyarrow import feather
 
 from res2df import ResdataFiles, common, grid, res2csv
 
@@ -518,7 +518,7 @@ def test_main_arrow(tmp_path, mocker):
     res2csv.main()
 
     # Read from disk and verify similarity
-    disk_frame_arrow = feather.read_table(tmp_path / "grid.arrow").to_pandas()
+    disk_frame_arrow = pa.feather.read_table(tmp_path / "grid.arrow").to_pandas()
     disk_frame_csv = pd.read_csv(tmp_path / "grid.csv")
 
     pd.testing.assert_frame_equal(disk_frame_arrow, disk_frame_csv, check_dtype=False)

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -5,9 +5,9 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 import yaml
-from pyarrow import feather
 from resdata.summary import Summary
 
 from res2df import csv2res, res2csv, summary
@@ -369,7 +369,7 @@ def test_main_subparser(tmp_path, mocker):
     )
     res2csv.main()
     assert Path(tmpcsvfile).is_file()
-    disk_arraydf = feather.read_table(tmparrowfile).to_pandas()
+    disk_arraydf = pa.feather.read_table(tmparrowfile).to_pandas()
     assert "FOPT" in disk_arraydf
 
     # Alternative and equivalent command line syntax for arrow output:
@@ -379,7 +379,7 @@ def test_main_subparser(tmp_path, mocker):
     )
     res2csv.main()
     pd.testing.assert_frame_equal(
-        disk_arraydf, feather.read_table(str(tmparrowfile_alt)).to_pandas()
+        disk_arraydf, pa.feather.read_table(str(tmparrowfile_alt)).to_pandas()
     )
 
     # Not possible (yet?) to write arrow to stdout:


### PR DESCRIPTION
Would fail in practise due to feather module not being available unless explicitly imported.