### PR TITLE
Disallow resdata beta versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies= [
-"resdata>=5.0.0-b0",
+"resdata>=5",
 "resfo",
 "networkx",
 "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies= [
 "resdata>=5",
 "resfo",
 "networkx",
-"numpy",
+"numpy<2.5",
 "opm>=2020.10.2",
 "pandas >= 2",
 "pyarrow",


### PR DESCRIPTION
Resolving:
```
 Downloaded pyarrow
 Downloaded jedi
Prepared 81 packages in 2.60s
error: Failed to install: resdata-7.0.0b2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (resdata==7.0.0b2)
  Caused by: failed to create directory `/opt/hostedtoolcache/Python/3.14.6/x64/python`: File exists (os error 17)
```
Ref.
https://github.com/equinor/res2df/actions/runs/28985043689

Having beta tags as part of pinning allows (other, newer) beta tags as candidates when installing.